### PR TITLE
Updated line reporting for ELIF statements

### DIFF
--- a/asteroid/frontend.py
+++ b/asteroid/frontend.py
@@ -314,27 +314,33 @@ class Parser:
             if_list = []
 
             dbg_print("parsing IF")
+            old_lineinfo = state.lineinfo
             self.lexer.match('IF')
             cond = self.exp()
             self.lexer.match('DO')
             stmts = self.stmt_list()
-            if_list.append(('if-clause', ('cond', cond), ('stmt-list', stmts)))
+            if_list.append(('if-clause', ('cond', cond), 
+                            ('stmt-list', stmts),('lineinfo',old_lineinfo)))
 
             while self.lexer.peek().type == 'ELIF':
                 dbg_print("parsing ELIF")
+                old_lineinfo = state.lineinfo
                 self.lexer.match('ELIF')
                 cond = self.exp()
                 self.lexer.match('DO')
                 stmts = self.stmt_list()
-                if_list.append(('if-clause', ('cond', cond), ('stmt-list', stmts)))
+                if_list.append(('if-clause', ('cond', cond), 
+                                ('stmt-list', stmts),('lineinfo',old_lineinfo)))
 
             if self.lexer.peek().type == 'ELSE':
                 dbg_print("parsing ELSE")
+                old_lineinfo = state.lineinfo
                 self.lexer.match('ELSE')
                 self.lexer.match_optional('DO')
                 stmts = self.stmt_list()
                 # make the else look like another elif with the condition set to 'true'
-                if_list.append(('if-clause', ('cond', ('boolean', True)), ('stmt-list', stmts)))
+                if_list.append(('if-clause', ('cond', ('boolean', True)), 
+                                ('stmt-list', stmts),('lineinfo',old_lineinfo)))
 
             self.lexer.match('END')
             #self.lexer.match_optional('IF')

--- a/asteroid/walk.py
+++ b/asteroid/walk.py
@@ -1100,7 +1100,9 @@ def if_stmt(node):
 
         (IF_CLAUSE,
          (COND, cond),
-         (STMT_LIST, stmts)) = if_clause
+         (STMT_LIST, stmts), line_info) = if_clause
+
+        process_lineinfo(line_info)
 
         (BOOLEAN, cond_val) = map2boolean(walk(cond))
 


### PR DESCRIPTION
Updated line reporting for ELIF statements:

ELIF statements now have their line recorded by the Asteroid interpreter, and when the evaluation/statement inside produces an error, the correct line number of the ELIF statement will be reported.

ELSE statements also now have their line number recorded, although they should not fail.