### PR TITLE
Handle parenthesized patterns. Fixes #90.

### DIFF
--- a/asteroid/frontend.py
+++ b/asteroid/frontend.py
@@ -45,6 +45,7 @@ primary_lookahead = {
 
 exp_lookahead = {
     'QUOTE',
+    'PATTERN',
     'LCONSTRAINT',} | primary_lookahead
 
 exp_lookahead_no_ops = exp_lookahead - ops - {'QUOTE'}

--- a/asteroid/test-suites/regression-tests/programs/test121.ast
+++ b/asteroid/test-suites/regression-tests/programs/test121.ast
@@ -1,0 +1,14 @@
+load system io.
+
+let p = (pattern with (x, y)).
+
+function foo
+	with *p do
+		println("matched").
+		assert(true).
+	with _ do
+		println("did not match").
+		assert(false).
+end
+
+foo(1, 2)


### PR DESCRIPTION
Add 'PATTERN' to expression lookahead to properly handle parenthesized patterns.
Fixes #90.