### PR TITLE
Fix for #41

### DIFF
--- a/asteroid/frontend.py
+++ b/asteroid/frontend.py
@@ -489,33 +489,34 @@ class Parser:
     def body_defs(self):
         dbg_print("parsing BODY_DEFS")
 
-        # a list of ('body', pattern, stmts) pairs
+        # a list of ('body', pattern, lineinfo, stmts) pairs
         body_list = []
-
+        
+        # Get the line info of the current pattern
         cur_lineinfo = state.lineinfo
+        
         self.lexer.match('WITH')
         p = self.pattern()
         self.lexer.match('DO')
         sl = self.stmt_list()
         body_list.append(
-            ('body', 
-                ('pattern', p, ('lineinfo', cur_lineinfo), ('stmt-list', sl) )
-            )
+            ('body', ('pattern', p, ('lineinfo', cur_lineinfo), ('stmt-list', sl) ))
         )
         
         while self.lexer.peek().type in ['ORWITH','WITH']:
             if self.lexer.peek().type == 'ORWITH':
                 warning("'orwith' has been deprecated, please replace with 'with'")
             
+            # Get the line info of the current pattern
             cur_lineinfo = state.lineinfo
+
             self.lexer.match(self.lexer.peek().type)
             p = self.pattern()
             self.lexer.match('DO')
             sl = self.stmt_list()
+            
             body_list.append(
-                ('body', 
-                    ('pattern', p, ('lineinfo', cur_lineinfo), ('stmt-list', sl) )
-                )
+                ('body', ('pattern', p, ('lineinfo', cur_lineinfo), ('stmt-list', sl) ))
             )
         return ('body-list', ('list', body_list))
 

--- a/asteroid/frontend.py
+++ b/asteroid/frontend.py
@@ -492,21 +492,31 @@ class Parser:
         # a list of ('body', pattern, stmts) pairs
         body_list = []
 
+        cur_lineinfo = state.lineinfo
         self.lexer.match('WITH')
         p = self.pattern()
         self.lexer.match('DO')
         sl = self.stmt_list()
-        body_list.append(('body', ('pattern', p), ('stmt-list', sl)))
-
+        body_list.append(
+            ('body', 
+                ('pattern', p, ('lineinfo', cur_lineinfo), ('stmt-list', sl) )
+            )
+        )
+        
         while self.lexer.peek().type in ['ORWITH','WITH']:
             if self.lexer.peek().type == 'ORWITH':
                 warning("'orwith' has been deprecated, please replace with 'with'")
+            
+            cur_lineinfo = state.lineinfo
             self.lexer.match(self.lexer.peek().type)
             p = self.pattern()
             self.lexer.match('DO')
             sl = self.stmt_list()
-            body_list.append(('body', ('pattern', p), ('stmt-list', sl)))
-
+            body_list.append(
+                ('body', 
+                    ('pattern', p, ('lineinfo', cur_lineinfo), ('stmt-list', sl) )
+                )
+            )
         return ('body-list', ('list', body_list))
 
     ###########################################################################################

--- a/asteroid/walk.py
+++ b/asteroid/walk.py
@@ -772,9 +772,10 @@ def handle_call(obj_ref, fval, actual_val_args, fname):
     for body in body_list_val:
 
         (BODY,
-         (PATTERN, p),
-         (STMT_LIST, stmts)) = body
+         (PATTERN, p, (lineinfo),
+         (STMT_LIST, stmts))) = body
 
+        process_lineinfo( lineinfo )
         try:
             unifiers = unify(actual_val_args, p)
             unified = True
@@ -795,6 +796,7 @@ def handle_call(obj_ref, fval, actual_val_args, fname):
     if obj_ref:
         state.symbol_table.enter_sym('this', obj_ref)
 
+    # TODO: FIX HERE
     # Check for useless patterns
     if state.eval_redundancy:
         check_redundancy(body_list, fname)
@@ -1614,16 +1616,18 @@ def check_redundancy( body_list, f_name ):
     for i in range(len(bodies)):
 
         #get the pattern with the higher level of precedence
-        (BODY_H,(PTRN,ptrn_h),stmts_h) = bodies[i]
+        (BODY_H, (PTRN,ptrn_h, lineinfo, stmts_h)) = bodies[i]
         assert_match(BODY_H,'body')
         assert_match(PTRN,'pattern')
+        process_lineinfo(lineinfo)
 
         for j in range(i + 1, len(bodies)):
 
             #get the pattern with the lower level of precedence
-            (BODY_L,(PTRN,ptrn_l),stmts_l) = bodies[j]
+            (BODY_L, (PTRN,ptrn_l, lineinfo, stmts_l)) = bodies[j]
             assert_match(BODY_L,'body')
             assert_match(PTRN,'pattern')
+            process_lineinfo(lineinfo)
 
             #Here we get line numbers in case we throw an error
             # we have to do a little 'tree walking' to get to the

--- a/asteroid/walk.py
+++ b/asteroid/walk.py
@@ -772,7 +772,7 @@ def handle_call(obj_ref, fval, actual_val_args, fname):
     for body in body_list_val:
 
         (BODY,
-         (PATTERN, p, (lineinfo),
+         (PATTERN, p, lineinfo,
          (STMT_LIST, stmts))) = body
 
         process_lineinfo( lineinfo )


### PR DESCRIPTION
This PR fixes issue #41 by adding lineinfo to the pattern portion of a function body. This allows for a program like 
```
function f
    with x if x < 10 do -- Error is here (Line 2)
        return 1.
    end

f("Asteroid"). -- Called here

```
To correctly report the error at the pattern match on line two as opposed to the call site on line six. 