### PR TITLE
implemented loc object for the index member function

### DIFF
--- a/asteroid/modules/prologue.ast
+++ b/asteroid/modules/prologue.ast
@@ -257,6 +257,24 @@ function range
     return [0 to stop-1].
   end
 
+  ------------------------------------------------------------------
+  structure loc
+  ------------------------------------------------------------------
+  -- object to identify locations for index member functions.
+  -- applies to both lists and strings.
+  with
+     data startix.
+     data endix.
+     function __init__
+        with (startval:%integer,endval:%integer) do
+           let this @startix = startval.
+           let this @endix = endval.
+        with startval:%integer do
+           let this @startix = startval.
+           let this @endix = none.
+        end
+  end
+
 ------------------------------------------------------------------
 -- List member functions
 ------------------------------------------------------------------
@@ -425,7 +443,7 @@ function __list_index__
 -- notation and are used to limit the search to a particular subsequence of
 -- the list. The returned index is computed relative to the beginning of the
 -- full sequence rather than the startix argument.
-with (item,startix:%integer,endix:%integer) do return escape
+with (item,loc(startix:%integer,endix:%integer)) do return escape
 "
 global __retval__
 
@@ -438,7 +456,7 @@ __retval__ = ('integer', this_val[1].index(item_val,
                             startix_val[1],
                             endix_val[1]))
 "
-with (item,startix:%integer) do return escape
+with (item,loc(startix:%integer,none)) do return escape
 "
 global __retval__
 
@@ -805,7 +823,7 @@ end
 ------------------------------------------------------------------
 function __string_index__
 ------------------------------------------------------------------
-with (item:%string,startix:%integer,endix:%integer) do return escape
+with (item:%string,loc(startix:%integer,endix:%integer)) do return escape
 "
 global __retval__
 
@@ -820,7 +838,7 @@ if val == -1:
 else:
     __retval__ = ('integer', val)
 "
-with (item:%string,startix:%integer) do return escape
+with (item:%string,loc(startix:%integer,none)) do return escape
 "
 global __retval__
 

--- a/asteroid/test-suites/regression-tests/programs/test122.ast
+++ b/asteroid/test-suites/regression-tests/programs/test122.ast
@@ -1,0 +1,3 @@
+assert ([1,2,3] @index(2,loc(0)) == 1).
+assert ("abcdef" @index("de",loc(0)) == 3).
+

--- a/docs/Reference Guide.rst
+++ b/docs/Reference Guide.rst
@@ -189,10 +189,10 @@ Member functions on lists can be called on the data structure directly, e.g.,
 * Function ``remove``, given ``(item)``, removes the first element from the list whose value is equal to ``(item)``. It raises a ValueError if there is no such item.
 * Function ``pop``, given ``(ix:%integer)``, removes the item at the given position in the list and returns it. If no index is specified,``a@pop()`` removes and returns the last item in the list.
 * Function ``clear``, given ``(none)``, removes all items from the list.
-* Function ``index`` returns a zero-based index in the list of the first element whose value is equal to ``(item)``. It raises a ValueError exception if there is no such item. The optional arguments ``(startix)`` and ``(endix)`` are interpreted as in the slice notation, and are used to limit the search to a particular subsequence of the list. The returned index is computed relative to the beginning of the full sequence rather than the ``(startix)`` argument.   This function can be called with several input configurations:
+* Function ``index`` returns a zero-based index in the list of the first element whose value is equal to ``(item)``. It raises a ValueError exception if there is no such item. The optional argument ``loc`` allows you to specify ``(startix)`` and ``(endix)`` and are used to limit the search to a particular subsequence of the list. The returned index is computed relative to the beginning of the full sequence rather than the ``(startix)`` argument.   This function can be called with several input configurations:
 
-  #. ``(item,startix:%integer,endix:%integer)``
-  #. ``(item,startix:%integer)``
+  #. ``(item,loc(startix:%integer,endix:%integer))``
+  #. ``(item,loc(startix:%integer))``
   #. ``item``
 
 * Function ``count``, given ``(item)``, returns the number of times ``(item)`` appears in the list.
@@ -253,10 +253,10 @@ data structure itself, e.g.
 
 * Function ``toupper``, converts all the lowercase letters in a string to uppercase.
 * Function ``tolower``, converts all the uppercase letters in a string to lowercase.
-* Function ``index`` allows the user to search for a given ``item`` in a list. It returns an integer index into the string or ``none`` if ``item`` was not found.  The function can be called with several different inputs:
+* Function ``index`` allows the user to search for a given ``item`` in a list. It returns an integer index into the string or ``none`` if ``item`` was not found.  The optional argument ``loc`` allows you to specify ``(startix)`` and ``(endix)`` and are used to limit the search to a particular substring of the string. The returned index is computed relative to the beginning of the full string rather than the ``(startix)`` argument.The function can be called with several different inputs:
 
-  #. Input ``(item:%string,startix:%integer,endix:%integer)``
-  #. Input ``(item:%string,startix:%integer)``
+  #. Input ``(item:%string,loc(startix:%integer,endix:%integer))``
+  #. Input ``(item:%string,loc(startix:%integer))``
   #. Input ``(item:%string)``
 
 * Function ``flip`` reverses a string.


### PR DESCRIPTION
implemented the `loc` object to hold optional values for the list/string index function in order to fix #76

Here is a simple program that demonstrates the usage of the `loc` object,
```
load system io.

println ([1,2,3] @index(2,loc(0))).
println ("abcdef" @index("de",loc(0))).
```