### PR TITLE
Updated line reporting for ELIF statements (Issue 93)

### DIFF
--- a/asteroid/frontend.py
+++ b/asteroid/frontend.py
@@ -314,27 +314,33 @@ class Parser:
             if_list = []
 
             dbg_print("parsing IF")
+            old_lineinfo = state.lineinfo
             self.lexer.match('IF')
             cond = self.exp()
             self.lexer.match('DO')
             stmts = self.stmt_list()
-            if_list.append(('if-clause', ('cond', cond), ('stmt-list', stmts)))
+            if_list.append(('if-clause', ('cond', cond), 
+                            ('stmt-list', stmts),('lineinfo',old_lineinfo)))
 
             while self.lexer.peek().type == 'ELIF':
                 dbg_print("parsing ELIF")
+                old_lineinfo = state.lineinfo
                 self.lexer.match('ELIF')
                 cond = self.exp()
                 self.lexer.match('DO')
                 stmts = self.stmt_list()
-                if_list.append(('if-clause', ('cond', cond), ('stmt-list', stmts)))
+                if_list.append(('if-clause', ('cond', cond), 
+                                ('stmt-list', stmts),('lineinfo',old_lineinfo)))
 
             if self.lexer.peek().type == 'ELSE':
                 dbg_print("parsing ELSE")
+                old_lineinfo = state.lineinfo
                 self.lexer.match('ELSE')
                 self.lexer.match_optional('DO')
                 stmts = self.stmt_list()
                 # make the else look like another elif with the condition set to 'true'
-                if_list.append(('if-clause', ('cond', ('boolean', True)), ('stmt-list', stmts)))
+                if_list.append(('if-clause', ('cond', ('boolean', True)), 
+                                ('stmt-list', stmts),('lineinfo',old_lineinfo)))
 
             self.lexer.match('END')
             #self.lexer.match_optional('IF')

--- a/asteroid/frontend.py
+++ b/asteroid/frontend.py
@@ -319,8 +319,8 @@ class Parser:
             cond = self.exp()
             self.lexer.match('DO')
             stmts = self.stmt_list()
-            if_list.append(('if-clause', ('cond', cond), 
-                            ('stmt-list', stmts),('lineinfo',old_lineinfo)))
+            if_list.append(('lineinfo',old_lineinfo))
+            if_list.append(('if-clause', ('cond', cond), ('stmt-list', stmts)))
 
             while self.lexer.peek().type == 'ELIF':
                 dbg_print("parsing ELIF")
@@ -329,8 +329,8 @@ class Parser:
                 cond = self.exp()
                 self.lexer.match('DO')
                 stmts = self.stmt_list()
-                if_list.append(('if-clause', ('cond', cond), 
-                                ('stmt-list', stmts),('lineinfo',old_lineinfo)))
+                if_list.append(('lineinfo',old_lineinfo))
+                if_list.append(('if-clause', ('cond', cond), ('stmt-list', stmts)))
 
             if self.lexer.peek().type == 'ELSE':
                 dbg_print("parsing ELSE")
@@ -338,9 +338,9 @@ class Parser:
                 self.lexer.match('ELSE')
                 self.lexer.match_optional('DO')
                 stmts = self.stmt_list()
+                if_list.append(('lineinfo',old_lineinfo))
                 # make the else look like another elif with the condition set to 'true'
-                if_list.append(('if-clause', ('cond', ('boolean', True)), 
-                                ('stmt-list', stmts),('lineinfo',old_lineinfo)))
+                if_list.append(('if-clause', ('cond', ('boolean', True)), ('stmt-list', stmts)))
 
             self.lexer.match('END')
             #self.lexer.match_optional('IF')

--- a/asteroid/test-suites/regression-tests/programs/test127.ast
+++ b/asteroid/test-suites/regression-tests/programs/test127.ast
@@ -2,7 +2,7 @@
 -- This tests is for ELIF line number reporting
 
 
-function lineNumberTest with none do escape
+escape
 " 
 from asteroid.interp import interp
 from asteroid.state import state
@@ -18,7 +18,7 @@ program += '    ...\n'
 program += 'end\n'
 
 try:
-    interp(program)
+    interp(program,exceptions=True)
 except:
     pass
 
@@ -40,7 +40,7 @@ program += '\n'
 program += 'foo().\n'
 
 try:
-    interp(program)
+    interp(program,exceptions=True)
 except:
     pass
 
@@ -68,7 +68,7 @@ program += '\n'
 program += 'foo().\n'
 
 try:
-    interp(program)
+    interp(program,exceptions=True)
 except:
     pass
 
@@ -97,13 +97,9 @@ program += '    end\n'
 program += 'end\n'
 
 try:
-    interp(program)
+    interp(program,exceptions=True)
 except:
     pass
 
-assert( state.lineinfo[1] == 13 )
+assert( state.lineinfo[1] == 14 )
 "
-end
-
--- run the test
-lineNumberTest().

--- a/asteroid/test-suites/regression-tests/programs/test127.ast
+++ b/asteroid/test-suites/regression-tests/programs/test127.ast
@@ -1,0 +1,109 @@
+
+-- This tests is for ELIF line number reporting
+
+
+function lineNumberTest with none do escape
+" 
+from asteroid.interp import interp
+from asteroid.state import state
+
+program = ''
+program += 'let x = 1.\n'
+program += 'let y = 0.\n'
+program += '\n'
+program += 'if ( x < 0) do\n'
+program += '    ...\n'
+program += 'elif ( x / y < 1 ) do-- division by zero \n'
+program += '    ...\n'
+program += 'end\n'
+
+try:
+    interp(program)
+except:
+    pass
+
+assert( state.lineinfo[1] == 6)
+
+program = ''
+program += 'let x = 1.\n'
+program += 'let y = 0.\n'
+program += '\n'
+program += 'function foo\n'
+program += '    with none do\n'
+program += '        if ( x < 0) do\n'
+program += '            ...\n'
+program += '        elif ( x / y < 1 ) do-- division by zero \n'
+program += '            ...\n'
+program += '        end\n'
+program += '    end\n'
+program += '\n'
+program += 'foo().\n'
+
+try:
+    interp(program)
+except:
+    pass
+
+assert( state.lineinfo[1] == 8)
+
+program = ''
+program += 'let x = 1.\n'
+program += 'let y = 0.\n'
+program += '\n'
+program += 'function foo\n'
+program += '    with none do\n'
+program += '        if ( x < 0) do\n'
+program += '            ...\n'
+program += '        elif ( x < 0 ) do\n'
+program += '            ...\n'
+program += '        elif ( x < -1 ) do\n'
+program += '            ...\n'
+program += '        elif ( x / y < 1 ) do-- division by zero \n'
+program += '            ...\n'
+program += '        elif ( x < 10 ) do\n'
+program += '            ...\n'
+program += '        end\n'
+program += '    end\n'
+program += '\n'
+program += 'foo().\n'
+
+try:
+    interp(program)
+except:
+    pass
+
+assert( state.lineinfo[1] == 12)
+
+program = ''
+program += 'let x = 1.\n'
+program += 'let y = 0.\n'
+program += '\n'
+program += 'while (1) do\n'
+program += '    if ( x < 0) do\n'
+program += '        ...\n'
+program += '    elif ( x < 1 ) do\n'
+program += '        ...\n'
+program += '    elif ( x < -1 ) do\n'
+program += '        ...\n'
+program += '    elif ( x < -2 ) do\n'
+program += '        ...\n'
+program += '    elif ( x / y < 1 ) do -- error\n'
+program += '        ...\n'
+program += '    elif ( x < -11 ) do\n'
+program += '        ...\n'
+program += '    elif ( x < 11 ) do\n'
+program += '        ...\n'
+program += '    end\n'
+program += 'end\n'
+
+try:
+    interp(program)
+except:
+    pass
+
+assert( state.lineinfo[1] == 13 )
+"
+end
+
+-- run the test
+lineNumberTest().

--- a/asteroid/walk.py
+++ b/asteroid/walk.py
@@ -1096,13 +1096,14 @@ def if_stmt(node):
     assert_match(IF, 'if')
     assert_match(LIST, 'list')
 
-    for if_clause in if_list:
+    for i in range(0,len(if_list),2):
+        
+        lineinfo = if_list[ i ]
+        process_lineinfo(lineinfo)
 
         (IF_CLAUSE,
          (COND, cond),
-         (STMT_LIST, stmts), line_info) = if_clause
-
-        process_lineinfo(line_info)
+         (STMT_LIST, stmts)) = if_list[ i + 1 ]
 
         (BOOLEAN, cond_val) = map2boolean(walk(cond))
 

--- a/asteroid/walk.py
+++ b/asteroid/walk.py
@@ -1100,7 +1100,9 @@ def if_stmt(node):
 
         (IF_CLAUSE,
          (COND, cond),
-         (STMT_LIST, stmts)) = if_clause
+         (STMT_LIST, stmts), line_info) = if_clause
+
+        process_lineinfo(line_info)
 
         (BOOLEAN, cond_val) = map2boolean(walk(cond))
 


### PR DESCRIPTION
Updated line reporting for ELIF statements:

ELIF statements now have their line recorded by the Asteroid interpreter, and when the evaluation/statement inside produces an error, the correct line number of the ELIF statement will be reported.

ELSE statements also now have their line number recorded, although they cannot fail.