### PR TITLE
Fix for #40 - generalizes the 'deref' operator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 *~
 dist/
 asteroid_lang.egg-info/
+action-test68.png

--- a/asteroid/frontend.py
+++ b/asteroid/frontend.py
@@ -778,14 +778,14 @@ class Parser:
     #    | FALSE
     #    | NONE
     #    | ID
-    #    | '*' ID         // "dereference" a variable during pattern matching
+    #    | '*' call_or_index /* pattern dereferencing */
     #    | NOT call_or_index
     #    | MINUS call_or_index
     #    | PLUS call_or_index
     #    | ESCAPE STRING
     #    | EVAL exp
-    #    | '(' tuple_stuff ')' // tuple/parenthesized expr
-    #    | '[' list_stuff ']'  // list or list access
+    #    | '(' tuple_stuff ')' /* tuple/parenthesized expr */
+    #    | '[' list_stuff ']'  /* list or list access */
     #    | function_const
     #    | TYPEMATCH // TYPEMATCH == '%'<typename>
     def primary(self):
@@ -823,8 +823,8 @@ class Parser:
 
         elif tt == 'TIMES':
             self.lexer.match('TIMES')
-            id_tok = self.lexer.match('ID')
-            return ('deref', ('id', id_tok.value))
+            v = self.call_or_index()
+            return ('deref', v)
 
         elif tt == 'NOT':
             self.lexer.match('NOT')

--- a/asteroid/grammar.txt
+++ b/asteroid/grammar.txt
@@ -123,7 +123,7 @@
 
   ////////////////////////////////////////////////////////////////////////////////////////
   // primary expressions/patterns
-  
+
   primary
     : INTEGER
     | REAL
@@ -132,7 +132,7 @@
     | FALSE
     | NONE
     | ID
-    | '*' ID         /* "dereference" a variable during pattern matching */
+    | '*' call_or_index   /* pattern dereferencing */
     | NOT call_or_index
     | MINUS call_or_index
     | PLUS call_or_index

--- a/asteroid/test-suites/regression-tests/test128.ast
+++ b/asteroid/test-suites/regression-tests/test128.ast
@@ -1,0 +1,9 @@
+-- testing function calls within patterns
+
+function goo with none do
+  return pattern x.
+end
+
+let *goo() = 4.
+assert (x==4).
+

--- a/asteroid/walk.py
+++ b/asteroid/walk.py
@@ -391,9 +391,10 @@ def unify(term, pattern, unifying = True ):
                 check_repeated_symbols(unifier) #Ensure we have no non-linear patterns
                 return unifier
 
-    elif pattern[0] == 'deref':  # ('deref', ('id', sym))
-        (ID, sym) = pattern[1]
-        p = state.symbol_table.lookup_sym(sym)
+    elif pattern[0] == 'deref':  # ('deref', v)
+        # v can be an AST representing any computation
+        # that produces a pattern.
+        p = walk(pattern[1])
 
         #lhh
         #print("unifying \nterm:{}\npattern:{}\n".format(term,p))
@@ -1150,7 +1151,7 @@ def if_stmt(node):
     assert_match(LIST, 'list')
 
     for i in range(0,len(if_list),2):
-        
+
         lineinfo = if_list[ i ]
         process_lineinfo(lineinfo)
 
@@ -1462,7 +1463,7 @@ def to_list_exp(node):
         # Get the stride_val
         stride_val = int(stride_val)
 
-        # Change the direction of the stride value based on the 
+        # Change the direction of the stride value based on the
         # ends of the range. I.e. 5->1 has an implicit direction
         # of -1, 1->5 has a direction of +1
         direction = (1 if ix < ex else -1)
@@ -1470,7 +1471,7 @@ def to_list_exp(node):
 
         # We need to modify the ending index to acccount for python
         # ranges. For example, for 1->10 we want range(1, 10 + 1).
-        # Or, for the opposite, we want range(10, 1 - 1) to give 
+        # Or, for the opposite, we want range(10, 1 - 1) to give
         # us the full inclusive range. Thus, we can just add our
         # direction
         new_ex = ex + direction


### PR DESCRIPTION
This PR generalizes the 'deref' operator '*' so that it can be applied to any value producing expression, e.g.:
```
-- pattern as value
let *(pattern x) = 3.
assert (x == 3).

-- arbitrary value expressions can become patterns
let *(1+1) = 2.

-- function calls
function goo with none do return pattern x end
let *goo() = 3
assert (x==3).
```


