### PR TITLE
fixed #136

### DIFF
--- a/asteroid/modules/prologue.ast
+++ b/asteroid/modules/prologue.ast
@@ -54,8 +54,7 @@ elif item_val[0] == 'object':
 elif item_val[0] == 'struct':
     (STRUCT,
         (MEMBER_NAMES, (LIST, member_names)),
-        (STRUCT_MEMORY, (LIST, struct_memory)),
-        (STRUCT_SCOPE, t_struct_scope)) = item_val
+        (STRUCT_MEMORY, (LIST, struct_memory))) = item_val
     l = len(data_only(struct_memory))
     __retval__ = ('integer', l)
 


### PR DESCRIPTION
Structures should never push their scope onto the stack because then it is possible to have unqualified access to members as the bug report illustrated. This patch fixes this, rather than pushing the structure scope onto the stack we explicitly test for membership in the structure.  The program,
```
load system io.

structure A with
   data a.
   data b.
   data c.

   function __init__
      with none do
        io @println (a,b,c,__init__).
        io @println (this @a, this @b, this @c, this @__init__).
      end
end

let o = A().
```
is now properly rejected with,
```
Error: members.ast: 10: 'a' is not defined
```