### PR TITLE
The Asteroid REPL

### DIFF
--- a/asteroid/__init__.py
+++ b/asteroid/__init__.py
@@ -9,6 +9,7 @@ import cProfile
 import sys
 import os
 from asteroid.interp import interp
+from asteroid.repl import repl
 from asteroid.version import VERSION
 
 def display_help():
@@ -52,7 +53,11 @@ def main():
             sys.exit(0)
         flags[fl] = not flags[fl]
 
-    if flags['-h'] or len(sys.argv) == 1:
+    if len(sys.argv) == 1:
+        repl()
+        sys.exit(0)
+
+    if flags['-h']:
         display_help()
         sys.exit(0)
 

--- a/asteroid/frontend.py
+++ b/asteroid/frontend.py
@@ -274,7 +274,8 @@ class Parser:
             self.lexer.match('FOR')
             e = self.exp()
             if e[0] != 'in':
-                raise ExpectationError(msg="Expected 'in' expression in for loop", found="EOF")
+                raise ExpectationError(msg="Expected 'in' expression in for loop",
+                        found=self.lexer.peek().type)
 
             self.lexer.match('DO')
             sl = self.stmt_list()

--- a/asteroid/frontend.py
+++ b/asteroid/frontend.py
@@ -152,7 +152,7 @@ class Parser:
             if self.lexer.peek().type in ['STRING', 'ID']:
                 str_tok = self.lexer.match(self.lexer.peek().type)
             elif self.lexer.peek().type == 'EOF':
-                raise ExpectationError( ('module name', 'EOF') )
+                raise ExpectationError( msg="Expected valid module name, found EOF", found='EOF' )
             else:
                 raise SyntaxError("invalid module name '{}'"
                                   .format(self.lexer.peek().value))
@@ -274,7 +274,7 @@ class Parser:
             self.lexer.match('FOR')
             e = self.exp()
             if e[0] != 'in':
-                raise ExpectationError( ('in expression in for loop', 'EOF') )
+                raise ExpectationError(msg="Expected 'in' expression in for loop", found="EOF")
 
             self.lexer.match('DO')
             sl = self.stmt_list()
@@ -887,7 +887,10 @@ class Parser:
             return ('typematch', tok.value)
 
         else:
-            raise ExpectationError( ('primary expression', 'EOF') )
+            raise ExpectationError(
+                expected='primary expression',
+                found=self.lexer.peek().type)
+
             #raise SyntaxError("syntax error at '{}'"
                 # .format(self.lexer.peek().value))
 

--- a/asteroid/frontend.py
+++ b/asteroid/frontend.py
@@ -887,9 +887,9 @@ class Parser:
             return ('typematch', tok.value)
 
         else:
-            raise SyntaxError(
-                "syntax error at '{}'"
-                .format(self.lexer.peek().value))
+            raise ExpectationError( ('primary expression', 'EOF') )
+            #raise SyntaxError("syntax error at '{}'"
+                # .format(self.lexer.peek().value))
 
     ###########################################################################################
     # tuple_stuff

--- a/asteroid/frontend.py
+++ b/asteroid/frontend.py
@@ -275,7 +275,7 @@ class Parser:
             e = self.exp()
             if e[0] != 'in':
                 raise ExpectationError( ('in expression in for loop', 'EOF') )
-                #raise SyntaxError("expected 'in' expression in for loop")
+
             self.lexer.match('DO')
             sl = self.stmt_list()
             self.lexer.match('END')

--- a/asteroid/frontend.py
+++ b/asteroid/frontend.py
@@ -8,7 +8,7 @@ import os
 import sys
 from pathlib import Path, PurePath
 
-from asteroid.globals import asteroid_file_suffix
+from asteroid.globals import asteroid_file_suffix, ExpectationError
 from asteroid.lex import Lexer
 from asteroid.state import state, warning
 
@@ -151,6 +151,8 @@ class Parser:
             # allow module names without quotes
             if self.lexer.peek().type in ['STRING', 'ID']:
                 str_tok = self.lexer.match(self.lexer.peek().type)
+            elif self.lexer.peek().type == 'EOF':
+                raise ExpectationError( ('module name', 'EOF') )
             else:
                 raise SyntaxError("invalid module name '{}'"
                                   .format(self.lexer.peek().value))
@@ -272,7 +274,8 @@ class Parser:
             self.lexer.match('FOR')
             e = self.exp()
             if e[0] != 'in':
-                raise SyntaxError("expected 'in' expression in for loop")
+                raise ExpectationError( ('in expression in for loop', 'EOF') )
+                #raise SyntaxError("expected 'in' expression in for loop")
             self.lexer.match('DO')
             sl = self.stmt_list()
             self.lexer.match('END')

--- a/asteroid/globals.py
+++ b/asteroid/globals.py
@@ -84,7 +84,7 @@ class NonLinearPatternError(Exception):
 class ExpectationError(Exception):
     def __init__(self, value):
         self.found_EOF = (value[1] == 'EOF')
-        self.value = "expected '{}' found '{}'.".format(value[0], value[1])
+        self.value = "expected {} found {}.".format(str(value[0]), str(value[1]))
 
     def __str__(self):
         return(repr(self.value))

--- a/asteroid/globals.py
+++ b/asteroid/globals.py
@@ -82,9 +82,13 @@ class NonLinearPatternError(Exception):
         return(repr(self.value))
 #########################################################################
 class ExpectationError(Exception):
-    def __init__(self, value):
-        self.found_EOF = (value[1] == 'EOF')
-        self.value = "expected {} found {}.".format(str(value[0]), str(value[1]))
+    def __init__(self, found, msg=None, expected=None):
+        self.found_EOF = (found == 'EOF')
+
+        if msg:
+            self.value = msg
+        else:
+            self.value = "expected {} found {}.".format(str(expected), str(found))
 
     def __str__(self):
         return(repr(self.value))

--- a/asteroid/globals.py
+++ b/asteroid/globals.py
@@ -80,7 +80,14 @@ class NonLinearPatternError(Exception):
 
     def __str__(self):
         return(repr(self.value))
+#########################################################################
+class ExpectationError(Exception):
+    def __init__(self, value):
+        self.found_EOF = (value[1] == 'EOF')
+        self.value = "expected '{}' found '{}'.".format(value[0], value[1])
 
+    def __str__(self):
+        return(repr(self.value))
 ##############################################################################################
 # *** Part of the Redundant Pattern Detector ***
 #

--- a/asteroid/interp.py
+++ b/asteroid/interp.py
@@ -24,10 +24,12 @@ def interp(input_stream,
            symtab_dump=False,
            exceptions=False,
            redundancy=True,
-           prologue=True):
+           prologue=True,
+           initialize_state = True):
     try:
         # initialize state
-        state.initialize()
+        if initialize_state:
+            state.initialize()
 
         #lhh
         #print("path[0]: {}".format(sys.path[0]))

--- a/asteroid/interp.py
+++ b/asteroid/interp.py
@@ -86,21 +86,28 @@ def interp(input_stream,
             print("Error: {}: {}: unhandled Asteroid exception: {}"
                   .format(module, lineno, term2string(throw_val.value)))
 
-        sys.exit(1)
+        if not exceptions:
+            sys.exit(1)
 
     except ReturnValue as inst:
         module, lineno = state.lineinfo
         print("Error: {}: {}: return statement used outside a function environment"
               .format(module, lineno))
-        sys.exit(1)
+
+        if not exceptions:
+            sys.exit(1)
 
     except RedundantPatternFound as e:
         print("Error:  {}".format(e))
-        sys.exit(1)
+
+        if not exceptions:
+            sys.exit(1)
 
     except NonLinearPatternError as e:
         print("Error:  {}".format(e))
-        sys.exit(1)
+
+        if not exceptions:
+            sys.exit(1)
 
     except Exception as e:
         if exceptions: # rethrow the exception so that you can see the full backtrace
@@ -110,12 +117,17 @@ def interp(input_stream,
         else:
             module, lineno = state.lineinfo
             print("Error: {}: {}: {}".format(module, lineno, e))
-            sys.exit(1)
+
+            if not exceptions:
+                sys.exit(1)
 
     except  KeyboardInterrupt as e:
-            print("Error: keyboard interrupt")
+        print("Error: keyboard interrupt")
+        if not exceptions:
             sys.exit(1)
+            
 
     except  BaseException as e:
-            print("Error: {}".format(e))
+        print("Error: {}".format(e))
+        if not exceptions:
             sys.exit(1)

--- a/asteroid/lex.py
+++ b/asteroid/lex.py
@@ -7,6 +7,7 @@
 import re
 
 from asteroid.state import state, warning
+from asteroid.globals import ExpectationError
 
 # table that specifies the token value and type for keywords
 keywords = {
@@ -226,8 +227,7 @@ class Lexer:
         if token_type not in self.token_types:
             raise ValueError("unknown token type '{}'".format(token_type))
         elif token_type != self.curr_token.type:
-            raise ValueError("expected '{}' found '{}'."
-                             .format(token_type, self.curr_token.type))
+            raise ExpectationError( (token_type, self.curr_token.type) )
         else:
             dbg_print('matching {}'.format(token_type))
             ct = self.curr_token

--- a/asteroid/lex.py
+++ b/asteroid/lex.py
@@ -174,7 +174,7 @@ def tokenize(code):
             continue
         elif type == 'MISMATCH':
             if value == '\"':
-                raise ExpectationError( ('\"', 'EOF') )
+                raise ExpectationError(expected='\"', found='EOF')
 
             else:
                 raise ValueError("unexpected character '{}'".format(value))
@@ -231,7 +231,7 @@ class Lexer:
         if token_type not in self.token_types:
             raise ValueError("unknown token type '{}'".format(token_type))
         elif token_type != self.curr_token.type:
-            raise ExpectationError( (token_type, self.curr_token.type) )
+            raise ExpectationError( found=self.curr_token.type, expected=token_type)
         else:
             dbg_print('matching {}'.format(token_type))
             ct = self.curr_token

--- a/asteroid/lex.py
+++ b/asteroid/lex.py
@@ -173,7 +173,11 @@ def tokenize(code):
         elif type == 'WHITESPACE':
             continue
         elif type == 'MISMATCH':
-            raise ValueError("unexpected character '{}'".format(value))
+            if value == '\"':
+                raise ExpectationError( ('\"', 'EOF') )
+
+            else:
+                raise ValueError("unexpected character '{}'".format(value))
         # put the token onto the tokens list
         tokens.append(Token(type, value, module, line_num))
     # always append an EOF token so we never run out of tokens

--- a/asteroid/repl.py
+++ b/asteroid/repl.py
@@ -1,6 +1,8 @@
 from asteroid.interp import interp
 from asteroid.version import VERSION
 from asteroid.state import state
+from asteroid.globals import ExpectationError
+
 from sys import stdin
 import readline
 
@@ -20,12 +22,35 @@ def print_repl_menu():
 
 
 def run_repl():
-    while True:
-        line = input("> ")
+    arrow_prompt, continue_prompt = ("> ", ". ")
+    current_prompt = arrow_prompt
 
+    line = ""
+    while True:
+        line += " " + input(current_prompt)
+
+#        print("#######DEBUG#########")
+#        print(line)
+#        print("#####################")
         try:
-            interp(line, initialize_state=False, prologue=False)
+            interp(line, initialize_state=False, prologue=False, exceptions=True)
+            line = ""
+
+        except ExpectationError as e:
+            # If we expected something but found EOF, it's a continue
+            if e.found_EOF:
+                current_prompt = continue_prompt
+            else:
+                print(e)
+                line = ""
+
         except EOFError:
             break
-        except:
-            pass
+
+        except Exception as e:
+            # FIX THIS
+            print(e)
+            line = ""
+        else:
+            if current_prompt == continue_prompt:
+                current_prompt = arrow_prompt

--- a/asteroid/repl.py
+++ b/asteroid/repl.py
@@ -1,0 +1,31 @@
+from asteroid.interp import interp
+from asteroid.version import VERSION
+from asteroid.state import state
+from sys import stdin
+import readline
+
+def repl():
+    state.initialize()
+
+    print_repl_menu()
+    try:
+        run_repl()
+    except EOFError:
+        print()
+        pass
+
+def print_repl_menu():
+    print("Asteroid Version", VERSION)
+    print("Press CTRL+D to exit")
+
+
+def run_repl():
+    while True:
+        line = input("> ")
+
+        try:
+            interp(line, initialize_state=False, prologue=False)
+        except EOFError:
+            break
+        except:
+            pass

--- a/asteroid/repl.py
+++ b/asteroid/repl.py
@@ -30,6 +30,9 @@ def run_repl():
     # Our line to be interpreted
     line = ""
     while True:
+        """
+        This exception block handles line input, breaking, and exiting
+        """
         try:
             # Get the new input and append it to the previous line (Possibly empty)
             # with a newline in between
@@ -45,6 +48,10 @@ def run_repl():
             print()
             break
 
+        
+        """
+        This block handles interpretation, multiline input, and exception handling
+        """
         try:
             # Try to interpret the new statement
             interp(line, initialize_state=False, prologue=False, exceptions=True)
@@ -59,6 +66,7 @@ def run_repl():
             else:
                 print(e)
                 line = ""
+                current_prompt = arrow_prompt
 
         except Exception as e:
             # FIX THIS

--- a/asteroid/repl.py
+++ b/asteroid/repl.py
@@ -22,18 +22,34 @@ def print_repl_menu():
 
 
 def run_repl():
+    # The two different prompt types either > for a new statement
+    # or . for continuing one
     arrow_prompt, continue_prompt = ("> ", ". ")
     current_prompt = arrow_prompt
 
+    # Our line to be interpreted
     line = ""
     while True:
-        line += "\n" + input(current_prompt)
-
-#        print("#######DEBUG#########")
-#        print(line)
-#        print("#####################")
         try:
+            # Get the new input and append it to the previous line (Possibly empty)
+            # with a newline in between
+            line += "\n" + input(current_prompt)
+
+        except KeyboardInterrupt:
+            line = ""
+            current_prompt = arrow_prompt
+            print()
+            continue
+
+        except EOFError:
+            print()
+            break
+
+        try:
+            # Try to interpret the new statement
             interp(line, initialize_state=False, prologue=False, exceptions=True)
+
+            # Try to 
             line = ""
 
         except ExpectationError as e:
@@ -44,13 +60,11 @@ def run_repl():
                 print(e)
                 line = ""
 
-        except EOFError:
-            break
-
         except Exception as e:
             # FIX THIS
             print(e)
             line = ""
+            current_prompt = arrow_prompt
+
         else:
-            if current_prompt == continue_prompt:
-                current_prompt = arrow_prompt
+            current_prompt = arrow_prompt

--- a/asteroid/repl.py
+++ b/asteroid/repl.py
@@ -17,6 +17,7 @@ def repl():
 
 def print_repl_menu():
     print("Asteroid Version", VERSION)
+    print("Run \"asteroid -h\" for help")
     print("Press CTRL+D to exit")
 
 

--- a/asteroid/repl.py
+++ b/asteroid/repl.py
@@ -27,7 +27,7 @@ def run_repl():
 
     line = ""
     while True:
-        line += " " + input(current_prompt)
+        line += "\n" + input(current_prompt)
 
 #        print("#######DEBUG#########")
 #        print(line)

--- a/asteroid/repl.py
+++ b/asteroid/repl.py
@@ -8,7 +8,6 @@ import readline
 
 def repl():
     state.initialize()
-
     print_repl_menu()
     try:
         run_repl()
@@ -22,6 +21,7 @@ def print_repl_menu():
 
 
 def run_repl():
+
     # The two different prompt types either > for a new statement
     # or . for continuing one
     arrow_prompt, continue_prompt = ("> ", ". ")
@@ -47,14 +47,13 @@ def run_repl():
         except EOFError:
             print()
             break
-
         
         """
         Interpretation, multiline input, and exception handling
         """
         try:
             # Try to interpret the new statement
-            interp(line, initialize_state=False, prologue=False, exceptions=True)
+            interp(line, initialize_state=False, exceptions=True)
 
             # Try to 
             line = ""

--- a/asteroid/repl.py
+++ b/asteroid/repl.py
@@ -36,7 +36,14 @@ def run_repl():
         try:
             # Get the new input and append it to the previous line (Possibly empty)
             # with a newline in between
-            line += "\n" + input(current_prompt)
+
+            # If the line is empty, just set the line
+            if line == "":
+                line = input(current_prompt)
+
+            # Otherwhise append a new line
+            else:
+                line += "\n" + input(current_prompt)
 
         except KeyboardInterrupt:
             line = ""

--- a/asteroid/repl.py
+++ b/asteroid/repl.py
@@ -31,7 +31,7 @@ def run_repl():
     line = ""
     while True:
         """
-        This exception block handles line input, breaking, and exiting
+        Line input, breaking, and exiting
         """
         try:
             # Get the new input and append it to the previous line (Possibly empty)
@@ -50,7 +50,7 @@ def run_repl():
 
         
         """
-        This block handles interpretation, multiline input, and exception handling
+        Interpretation, multiline input, and exception handling
         """
         try:
             # Try to interpret the new statement


### PR DESCRIPTION
This PR implements a REPL for asteroid. The REPL is now the default run option for asteroid. (i.e. running `asteroid` runs the REPL).

The REPL has two basic functions:
* Basic Read-Eval-Print-Loop functionality
* Multi-line prompting/support

This PR also adds a new error class, `ExpectationError`. Technically a subset of all `SyntaxError`'s, this type of exception is raised when the parser/lexer *expected* a token but did not find it.

If possible, try to break this PR! I'm wondering if this scheme is robust enough.