### PR TITLE
Added support for floating point scientific notation. Fixes #34.

### DIFF
--- a/asteroid/lex.py
+++ b/asteroid/lex.py
@@ -59,41 +59,41 @@ keywords = {
 # this table defines tokens whose value is defined by a
 # regular expression.
 token_specs = [
-#   value:                          type:
-    (r'([0-9]*[.])?[0-9]+',         'NUMBER'),
-    (r'"([^"]|\\"|\\)*"',           'STRING'),
-    (r'(--.*)|(\#.*)',              'COMMENT'),
-    (r'[a-zA-Z_][a-zA-Z_0-9]*',     'ID'),
-    (r'\n',                         'NEWLINE'),
-    (r'[ \t]+',                     'WHITESPACE'),
-    (r'\%[a-zA-Z_][a-zA-Z_0-9]*',   'TYPEMATCH'),
-    (r'\+',                         'PLUS'),
-    (r'-',                          'MINUS'),
-    (r'\*',                         'TIMES'),
-    (r'/',                          'DIVIDE'),
-    (r'==',                         'EQ'),
-    (r'=/=',                        'NE'),
-    (r'<=',                         'LE'),
-    (r'<',                          'LT'),
-    (r'>=',                         'GE'),
-    (r'>',                          'GT'),
-    (r'@',                          'AT'),
-    (r'\%\[',                       'LCONSTRAINT'),
-    (r'\]\%',                       'RCONSTRAINT'),
-    (r'\(',                         'LPAREN'),
-    (r'\)',                         'RPAREN'),
-    (r'\[',                         'LBRACKET'),
-    (r'\]',                         'RBRACKET'),
-    (r':',                          'COLON'),
-    (r'\|',                         'BAR'),
-    (r'\.',                         'DOT'),
-    (r',',                          'COMMA'),
-    (r'=',                          'ASSIGN'),
-    (r'\'',                         'QUOTE'),
+#   value:                                                      type:
+    (r'[0-9]+([.][0-9]+)?((e|E)(\+|\-)?[0-9]+)?',               'NUMBER'),
+    (r'"([^"]|\\"|\\)*"',                                       'STRING'),
+    (r'(--.*)|(\#.*)',                                          'COMMENT'),
+    (r'[a-zA-Z_][a-zA-Z_0-9]*',                                 'ID'),
+    (r'\n',                                                     'NEWLINE'),
+    (r'[ \t]+',                                                 'WHITESPACE'),
+    (r'\%[a-zA-Z_][a-zA-Z_0-9]*',                               'TYPEMATCH'),
+    (r'\+',                                                     'PLUS'),
+    (r'-',                                                      'MINUS'),
+    (r'\*',                                                     'TIMES'),
+    (r'/',                                                      'DIVIDE'),
+    (r'==',                                                     'EQ'),
+    (r'=/=',                                                    'NE'),
+    (r'<=',                                                     'LE'),
+    (r'<',                                                      'LT'),
+    (r'>=',                                                     'GE'),
+    (r'>',                                                      'GT'),
+    (r'@',                                                      'AT'),
+    (r'\%\[',                                                   'LCONSTRAINT'),
+    (r'\]\%',                                                   'RCONSTRAINT'),
+    (r'\(',                                                     'LPAREN'),
+    (r'\)',                                                     'RPAREN'),
+    (r'\[',                                                     'LBRACKET'),
+    (r'\]',                                                     'RBRACKET'),
+    (r':',                                                      'COLON'),
+    (r'\|',                                                     'BAR'),
+    (r'\.',                                                     'DOT'),
+    (r',',                                                      'COMMA'),
+    (r'=',                                                      'ASSIGN'),
+    (r'\'',                                                     'QUOTE'),
     # this is the catch-all pattern, it has to be
     # here do that we can report illegal characters
     # in the input.
-    (r'.',                          'MISMATCH'),
+    (r'.',                                                      'MISMATCH'),
 ]
 
 # this table specifies token types that are used in the tokenizer
@@ -135,7 +135,7 @@ def tokenize(code):
         value = mo.group()
         # some special processing of tokens
         if type == 'NUMBER':
-            if '.' in value:
+            if '.' in value or 'e' in value or 'E' in value:
                 type = 'REAL'
                 value = float(value)
             else:

--- a/asteroid/modules/type.ast
+++ b/asteroid/modules/type.ast
@@ -21,13 +21,20 @@ structure __STRINGFORMAT__
 with
   data length.
   data precision.
+  data scientific.
   function __init__
+    with (l:%integer,p:%integer,s:%boolean) do
+      let this @length = l.
+      let this @precision = p.
+      let this @scientific = s.
     with (l:%integer,p:%integer) do
       let this @length = l.
       let this @precision = p.
+      let this @scientific = none.
     with l:%integer do
       let this @length = l.
       let this @precision = none.
+      let this @scientific = none.
     end
 end
 
@@ -89,7 +96,7 @@ function tostring
 -- if format values are given apply the
 -- formatting to the object.
 
-with (v:*__TP__,__STRINGFORMAT__(w:%integer,none)) do
+with (v:*__TP__,__STRINGFORMAT__(w:%integer,none,none)) do
   -- booleans, integers, and strings (see TP pattern) with width spec are
   -- right justified. if width spec is too narrow it is ignored.
   let vs = this @tostring(v).
@@ -99,25 +106,40 @@ with (v:*__TP__,__STRINGFORMAT__(w:%integer,none)) do
   else do
     return vs.
   end
-with (v:%real,__STRINGFORMAT__(w:%integer,none)) do return escape
+with (v:%real,__STRINGFORMAT__(w:%integer,none,none)) do return escape
 -- floating point values with only a width spec are left justified with
 -- zero padding on the right.
 "
 global __retval__
 (V_TYPE, v_val) = state.symbol_table.lookup_sym('v')
 (W_TYPE, w_val) = state.symbol_table.lookup_sym('w')
+
 fmtstr = '{:'+str(w_val)+'f}'
 __retval__ = ('string', fmtstr.format(v_val))
 "
 -- floating point values with a width and precision specs
 -- are formatted according to Python formatting rules
-with (v:%real,__STRINGFORMAT__(w:%integer,p:%integer)) do return escape
+with (v:%real,__STRINGFORMAT__(w:%integer,p:%integer,none)) do return escape
 "
 global __retval__
 (V_TYPE, v_val) = state.symbol_table.lookup_sym('v')
 (W_TYPE, w_val) = state.symbol_table.lookup_sym('w')
 (P_TYPE, p_val) = state.symbol_table.lookup_sym('p')
+
 fmtstr = '{:'+str(w_val)+'.'+str(p_val)+'f}'
+__retval__ = ('string', fmtstr.format(v_val))
+"
+-- floating point values with width, precision and scientific notation specs
+-- are formatted according to Python formatting rules
+with (v:%real,__STRINGFORMAT__(w:%integer,p:%integer,s:%boolean)) do return escape
+"
+global __retval__
+(V_TYPE, v_val) = state.symbol_table.lookup_sym('v')
+(W_TYPE, w_val) = state.symbol_table.lookup_sym('w')
+(P_TYPE, p_val) = state.symbol_table.lookup_sym('p')
+(S_TYPE, s_val) = state.symbol_table.lookup_sym('s')
+
+fmtstr = '{:'+str(w_val)+'.'+str(p_val)+('e}' if s_val else 'f}')
 __retval__ = ('string', fmtstr.format(v_val))
 "
 with item do return escape
@@ -136,6 +158,8 @@ function stringformat
 ------------------------------------------------------------------
 -- a wrapper around our __STRINGFORMAT__ object as a member
 -- of our module.
+with (l:%integer,p:%integer,s:%boolean) do
+  return __STRINGFORMAT__(l,p,s).
 with (l:%integer,p:%integer) do
   return __STRINGFORMAT__(l,p).
 with l:%integer do

--- a/asteroid/test-suites/regression-tests/test129.ast
+++ b/asteroid/test-suites/regression-tests/test129.ast
@@ -1,0 +1,23 @@
+load system io.
+
+let E = 10.3e-12.
+let e = -3E+1.
+let n = E + e - 4.00e01 + 0.1.
+io @println(n).
+assert(n == -69.8999999999897).
+
+let s = type @tostring(n,type @stringformat(10,10,true)).
+io @println(s).
+assert(s == "-6.9900000000e+01").
+
+let s = type @tostring(n,type @stringformat(10,10,false)).
+io @println(s).
+assert(s == "-69.9000000000").
+
+let y = 1.
+io @println(type @gettype(y)).
+assert(type @gettype(y) == "integer").
+
+let z = 1.0.
+io @println(type @gettype(z)).
+assert(type @gettype(z) == "real").

--- a/asteroid/test-suites/ug-programs/prgm-033.ast
+++ b/asteroid/test-suites/ug-programs/prgm-033.ast
@@ -12,7 +12,7 @@
 
     try
         let i = random @random().
-        if i >= .5 do
+        if i >= 0.5 do
             throw Head(i).
         else do
             throw Tail(i).

--- a/docs/Reference Guide.txt
+++ b/docs/Reference Guide.txt
@@ -343,12 +343,13 @@ The `type <https://github.com/asteroid-lang/asteroid/blob/master/asteroid/module
 
 * Function ``toreal``, given ``item``, returns the input as a real number data type.
 * Function ``toboolean``, given ``item``, returns the input as a Boolean value of either true or false.
-* Function ``tostring`` converts an Asteroid object to a string. If format values are given, it applies the formatting to the object. It can be called with several different inputs where ``*TP`` indicates a``boolean``, ``integer``, or ``string`` type and ``w`` is the width specification and ``p`` is the precision specification.  When no formatting information is provided a default string conversion occurs,
+* Function ``tostring`` converts an Asteroid object to a string. If format values are given, it applies the formatting to the object. It can be called with several different inputs where ``*TP`` indicates a``boolean``, ``integer``, or ``string`` type and ``w`` is the width specification, ``p`` is the precision specification and ``s`` is the scientific notation flag.  When no formatting information is provided a default string conversion occurs,
 
   1. ``(v:*TP,type @stringformat(w:%integer))``
   2. ``(v:%real,type @stringformat(w:%integer))``
   3. ``(v:%real,type @stringformat(w:%integer,p:%integer))``
-  4. ``item`` - default conversion
+  4. ``(v:%real,type @stringformat(w:%integer,p:%integer,s:%boolean))``
+  5. ``item`` - default conversion
 
 * Function ``tobase`` represents the given integer ``x`` (*specifically* within the given input ``(x:%integer,base:%integer)``) as a string in the given base.
 


### PR DESCRIPTION
Added support for floating point scientific notation. Fixes #34.
Updated test cases to conform to new numeric parsing (e.g. mandatory leading zero).