### PR TITLE
Issue 126 - clean up error messages

### DIFF
--- a/asteroid/modules/math.ast
+++ b/asteroid/modules/math.ast
@@ -101,7 +101,7 @@ val_b = state.symbol_table.lookup_sym('b')
 val_p = state.symbol_table.lookup_sym('p')
 
 if val_b[0] not in ['integer','real']:
-  raise ValueError('unsupported type {} for pow'.format(val_b[0]))
+  raise ValueError('unsupported type \'{}\' for pow'.format(val_b[0]))
 
 __retval__ = (val_b[0],val_b[1]**val_p[1])
 "
@@ -118,7 +118,7 @@ from math import sqrt
 
 val_a = state.symbol_table.lookup_sym('a')
 if val_a[0] not in ['integer','real']:
-  raise ValueError('unsupported type {} for sqrt'.format(val_a[0]))
+  raise ValueError('unsupported type \'{}\' for sqrt'.format(val_a[0]))
 __retval__ = ('real',sqrt(val_a[1]))
 "
 end
@@ -234,10 +234,10 @@ val_v = state.symbol_table.lookup_sym('v')
 val_d = state.symbol_table.lookup_sym('d')
 
 if val_v[0] not in ['integer','real']:
-  raise ValueError('unsupported type {} for mod'.format(val_v[0]))
+  raise ValueError('unsupported type \'{}\' for mod'.format(val_v[0]))
 
 if val_d[0] not in ['integer','real']:
-  raise ValueError('unsupported type {} for mod'.format(val_d[0]))
+  raise ValueError('unsupported type \'{}\' for mod'.format(val_d[0]))
 
 __retval__ = (promote(val_v[0],val_d[0]),val_v[1] % val_d[1])
 "

--- a/asteroid/modules/prologue.ast
+++ b/asteroid/modules/prologue.ast
@@ -60,7 +60,7 @@ elif item_val[0] == 'struct':
 
 else:
     raise ValueError(
-   	  'len expected a list, tuple, string, or structure got {}'
+   	  'len expected a list, tuple, string, or structure got \'{}\''
 	    .format(item_val[0]))
 "
 end
@@ -227,7 +227,7 @@ this_val = state.symbol_table.lookup_sym('this')
 item_val = state.symbol_table.lookup_sym('item')
 
 if item_val[0] not in ['list', 'string', 'tuple']:
-    raise ValueError('extend expected a list, string, or tuple, got {}'
+    raise ValueError('extend expected a list, string, or tuple, got \'{}\''
                 .format(item_val[0]))
 
 __retval__ = ('list', this_val[1].extend(item_val[1]))

--- a/asteroid/test-suites/regression-tests/test002.ast
+++ b/asteroid/test-suites/regression-tests/test002.ast
@@ -85,7 +85,7 @@ try
   let v = 1 if v == 2.
   throw Error("FAIL: no expected error ").
 catch Exception("SystemError", s) do
-  if not isnone(s @index("else clause")) do
+  if not isnone(s @index("'else' clause")) do
   . -- pass
   else
     throw Error("FAIL: unexpected error "+s).


### PR DESCRIPTION
Cleaned up all error message.  For example, the program,
```
load system io.

let x = 1
io @println "hello".
```
now issues the message,
```
Error: msg.ast: 3: term '1' is not a function, did you forget the end-of-line period?
```
and the program,
```
function foo with x:%integer do
   return x.
end

foo("hello").
```
now issues the message,
```
Error: msg1.ast: 1: actual argument 'hello' not recognized by function 'foo'
```
