### PR TITLE
fixes for issue #89 - lambda functions and patterns as booleans

### DIFF
--- a/asteroid/support.py
+++ b/asteroid/support.py
@@ -141,10 +141,10 @@ def map2boolean(value):
     elif value[0] == 'boolean':
         return value
 
-    elif value[0] in  ['integer', 'real', 'list', 'string']:
+    elif value[0] in  ['integer', 'real', 'list', 'tuple', 'string']:
         return ('boolean', bool(value[1]))
 
-    elif value[0] == 'object':
+    elif value[0] in ['object', 'function-val', 'pattern']:
         return ('boolean', True)
 
     else:

--- a/asteroid/test-suites/regression-tests/test133.ast
+++ b/asteroid/test-suites/regression-tests/test133.ast
@@ -1,0 +1,13 @@
+-- testing structures as boolean values
+assert(lambda with x do return x+1).
+assert(pattern x).
+assert((1,2)).
+assert(not ()).
+
+structure A with
+   data a.
+   data b.
+end
+
+assert(A(1,2)).
+


### PR DESCRIPTION
Asteroid now properly handles the following as Boolean values,
```
assert(lambda with x do return x+1). -- lambda as boolean
assert(pattern x). -- pattern as boolean
assert((1,2)). -- tuple as boolean
assert(not ()). -- the empty tuple as boolean

structure A with
   data a.
   data b.
end

assert(A(1,2)). -- object as boolean
```
