### PR TITLE
fixes issue #149

### DIFF
--- a/asteroid/frontend.py
+++ b/asteroid/frontend.py
@@ -9,7 +9,7 @@ import sys
 from pathlib import Path, PurePath
 
 from asteroid.globals import asteroid_file_suffix, ExpectationError
-from asteroid.lex import Lexer
+from asteroid.lex import Lexer, token_lookup
 from asteroid.state import state, warning
 
 ###########################################################################################
@@ -91,7 +91,7 @@ class Parser:
         sl = self.stmt_list()
         if not self.lexer.EOF():
             raise SyntaxError("expected 'EOF' found '{}'." \
-                              .format(self.lexer.peek().type))
+                              .format(token_lookup(self.lexer.peek().type)))
         else:
             dbg_print("parsing EOF")
         return sl
@@ -149,7 +149,7 @@ class Parser:
             if self.lexer.peek().type in ['STRING', 'ID']:
                 str_tok = self.lexer.match(self.lexer.peek().type)
             elif self.lexer.peek().type == 'EOF':
-                raise ExpectationError( msg="Expected valid module name, found EOF", found='EOF' )
+                raise ExpectationError(expected="valid module name", found='EOF' )
             else:
                 raise SyntaxError("invalid module name '{}'"
                                   .format(self.lexer.peek().value))
@@ -264,8 +264,9 @@ class Parser:
             self.lexer.match('FOR')
             e = self.exp()
             if e[0] != 'in':
-                raise ExpectationError(msg="Expected 'in' expression in for loop",
-                        found=self.lexer.peek().type)
+                raise ExpectationError(
+                        expected="'in' expression in for loop",
+                        found=token_lookup(self.lexer.peek().type))
 
             self.lexer.match('DO')
             sl = self.stmt_list()
@@ -865,8 +866,8 @@ class Parser:
 
         else:
             raise ExpectationError(
-                expected='primary expression',
-                found=self.lexer.peek().type)
+                expected='expression',
+                found=token_lookup(self.lexer.peek().type))
 
             #raise SyntaxError("syntax error at '{}'"
                 # .format(self.lexer.peek().value))

--- a/asteroid/globals.py
+++ b/asteroid/globals.py
@@ -82,13 +82,9 @@ class NonLinearPatternError(Exception):
         return(repr(self.value))
 #########################################################################
 class ExpectationError(Exception):
-    def __init__(self, found, msg=None, expected=None):
+    def __init__(self, found, expected):
         self.found_EOF = (found == 'EOF')
-
-        if msg:
-            self.value = msg
-        else:
-            self.value = "expected {} found {}.".format(str(expected), str(found))
+        self.value = "expected {} found {}.".format(str(expected), str(found))
 
     def __str__(self):
         return(repr(self.value))

--- a/asteroid/interp.py
+++ b/asteroid/interp.py
@@ -1,7 +1,7 @@
 ###########################################################################################
 # Asteroid interpreter
 #
-# (c) Lutz Hamel, University of Rhode Island
+# (c) University of Rhode Island
 ###########################################################################################
 
 import os
@@ -40,7 +40,6 @@ def interp(input_stream,
 
         # read in prologue
         if prologue:
-
             prologue_file = ''
             prologue_file_base = os.path.join('modules', prologue_name)
             module_path = os.path.join(os.path.split(os.path.abspath(__file__))[0], prologue_file_base)
@@ -85,29 +84,30 @@ def interp(input_stream,
         else:
             print("Error: {}: {}: unhandled Asteroid exception: {}"
                   .format(module, lineno, term2string(throw_val.value)))
-
-        if not exceptions:
-            sys.exit(1)
+        sys.exit(1)
 
     except ReturnValue as inst:
         module, lineno = state.lineinfo
         print("Error: {}: {}: return statement used outside a function environment"
               .format(module, lineno))
-
-        if not exceptions:
-            sys.exit(1)
+        sys.exit(1)
 
     except RedundantPatternFound as e:
         print("Error:  {}".format(e))
-
-        if not exceptions:
-            sys.exit(1)
+        sys.exit(1)
 
     except NonLinearPatternError as e:
         print("Error:  {}".format(e))
+        sys.exit(1)
 
-        if not exceptions:
-            sys.exit(1)
+    except ExpectationError as e:
+        module, lineno = state.lineinfo
+        print("Error: {}: {}: {}".format(module, lineno, e.value))
+        sys.exit(1)
+
+    except  KeyboardInterrupt as e:
+        print("Error: keyboard interrupt")
+        sys.exit(1)
 
     except Exception as e:
         if exceptions: # rethrow the exception so that you can see the full backtrace
@@ -117,17 +117,8 @@ def interp(input_stream,
         else:
             module, lineno = state.lineinfo
             print("Error: {}: {}: {}".format(module, lineno, e))
-
-            if not exceptions:
-                sys.exit(1)
-
-    except  KeyboardInterrupt as e:
-        print("Error: keyboard interrupt")
-        if not exceptions:
             sys.exit(1)
-            
 
     except  BaseException as e:
         print("Error: {}".format(e))
-        if not exceptions:
-            sys.exit(1)
+        sys.exit(1)

--- a/asteroid/interp.py
+++ b/asteroid/interp.py
@@ -108,18 +108,23 @@ def interp(input_stream,
         if not exceptions:
             sys.exit(1)
 
-    except ExpectationError as e:
-        module, lineno = state.lineinfo
-        print("Error: {}: {}: {}".format(module, lineno, e.value))
-        # needed for REPL
-        if not exceptions:
-            sys.exit(1)
-
     except  KeyboardInterrupt as e:
         print("Error: keyboard interrupt")
         # needed for REPL
         if not exceptions:
             sys.exit(1)
+
+    # Expectation Error is used by the REPL, so, like exceptions,
+    # we re throw it
+    except ExpectationError as e:
+        if exceptions:
+            raise e
+        else:
+            module, lineno = state.lineinfo
+            print("Error: {}: {}: {}".format(module, lineno, e.value))
+            # needed for REPL
+            if not exceptions:
+                sys.exit(1)
 
     except Exception as e:
         if exceptions: # rethrow the exception so that you can see the full backtrace

--- a/asteroid/interp.py
+++ b/asteroid/interp.py
@@ -84,30 +84,42 @@ def interp(input_stream,
         else:
             print("Error: {}: {}: unhandled Asteroid exception: {}"
                   .format(module, lineno, term2string(throw_val.value)))
-        sys.exit(1)
+        # needed for REPL
+        if not exceptions:
+            sys.exit(1)
 
     except ReturnValue as inst:
         module, lineno = state.lineinfo
         print("Error: {}: {}: return statement used outside a function environment"
               .format(module, lineno))
-        sys.exit(1)
+        # needed for REPL
+        if not exceptions:
+            sys.exit(1)
 
     except RedundantPatternFound as e:
         print("Error:  {}".format(e))
-        sys.exit(1)
+        # needed for REPL
+        if not exceptions:
+            sys.exit(1)
 
     except NonLinearPatternError as e:
         print("Error:  {}".format(e))
-        sys.exit(1)
+        # needed for REPL
+        if not exceptions:
+            sys.exit(1)
 
     except ExpectationError as e:
         module, lineno = state.lineinfo
         print("Error: {}: {}: {}".format(module, lineno, e.value))
-        sys.exit(1)
+        # needed for REPL
+        if not exceptions:
+            sys.exit(1)
 
     except  KeyboardInterrupt as e:
         print("Error: keyboard interrupt")
-        sys.exit(1)
+        # needed for REPL
+        if not exceptions:
+            sys.exit(1)
 
     except Exception as e:
         if exceptions: # rethrow the exception so that you can see the full backtrace
@@ -117,8 +129,12 @@ def interp(input_stream,
         else:
             module, lineno = state.lineinfo
             print("Error: {}: {}: {}".format(module, lineno, e))
-            sys.exit(1)
+            # needed for REPL
+            if not exceptions:
+                sys.exit(1)
 
     except  BaseException as e:
         print("Error: {}".format(e))
-        sys.exit(1)
+        # needed for REPL
+        if not exceptions:
+            sys.exit(1)

--- a/asteroid/lex.py
+++ b/asteroid/lex.py
@@ -111,6 +111,7 @@ def init_token_values():
     # grab tokens from token_specs table
     token_values.update({'INTEGER':'integer value'})
     token_values.update({'REAL':'real value'})
+    token_values.update({'EOF':'EOF'})
     for (_,display,type) in token_specs:
         token_values.update({type:display})
 

--- a/asteroid/lex.py
+++ b/asteroid/lex.py
@@ -58,40 +58,40 @@ keywords = {
 # this table defines tokens whose value is defined by a
 # regular expression.
 token_specs = [
-#   value:                                                      type:
-    (r'[0-9]+([.][0-9]+)?((e|E)(\+|\-)?[0-9]+)?',               'NUMBER'),
-    (r'"([^"]|\\"|\\)*"',                                       'STRING'),
-    (r'(--.*)|(\#.*)',                                          'COMMENT'),
-    (r'[a-zA-Z_][a-zA-Z_0-9]*',                                 'ID'),
-    (r'\n',                                                     'NEWLINE'),
-    (r'[ \t]+',                                                 'WHITESPACE'),
-    (r'\%[a-zA-Z_][a-zA-Z_0-9]*',                               'TYPEMATCH'),
-    (r'\+',                                                     'PLUS'),
-    (r'-',                                                      'MINUS'),
-    (r'\*',                                                     'TIMES'),
-    (r'/',                                                      'DIVIDE'),
-    (r'==',                                                     'EQ'),
-    (r'=/=',                                                    'NE'),
-    (r'<=',                                                     'LE'),
-    (r'<',                                                      'LT'),
-    (r'>=',                                                     'GE'),
-    (r'>',                                                      'GT'),
-    (r'@',                                                      'AT'),
-    (r'\%\[',                                                   'LCONSTRAINT'),
-    (r'\]\%',                                                   'RCONSTRAINT'),
-    (r'\(',                                                     'LPAREN'),
-    (r'\)',                                                     'RPAREN'),
-    (r'\[',                                                     'LBRACKET'),
-    (r'\]',                                                     'RBRACKET'),
-    (r':',                                                      'COLON'),
-    (r'\|',                                                     'BAR'),
-    (r'\.',                                                     'DOT'),
-    (r',',                                                      'COMMA'),
-    (r'=',                                                      'ASSIGN'),
+#   value:                                        display:      type:
+    (r'[0-9]+([.][0-9]+)?((e|E)(\+|\-)?[0-9]+)?', "number",     'NUMBER'),
+    (r'"([^"]|\\"|\\)*"',                         "string",     'STRING'),
+    (r'(--.*)|(\#.*)',                            "comment",    'COMMENT'),
+    (r'[a-zA-Z_][a-zA-Z_0-9]*',                   "variable",   'ID'),
+    (r'\n',                                       "\n",         'NEWLINE'),
+    (r'[ \t]+',                                   "space/tab",  'WHITESPACE'),
+    (r'\%[a-zA-Z_][a-zA-Z_0-9]*',                 "%type",      'TYPEMATCH'),
+    (r'\+',                                       "'+'",        'PLUS'),
+    (r'-',                                        "'-'",        'MINUS'),
+    (r'\*',                                       "'*'",        'TIMES'),
+    (r'/',                                        "'/'",        'DIVIDE'),
+    (r'==',                                       "'=='",       'EQ'),
+    (r'=/=',                                      "'=/='",      'NE'),
+    (r'<=',                                       "'<='",       'LE'),
+    (r'<',                                        "'<'",        'LT'),
+    (r'>=',                                       "'>='",       'GE'),
+    (r'>',                                        "'>'",        'GT'),
+    (r'@',                                        "'@'",        'AT'),
+    (r'\%\[',                                     "'%['",       'LCONSTRAINT'),
+    (r'\]\%',                                     "']%'",       'RCONSTRAINT'),
+    (r'\(',                                       "'('",        'LPAREN'),
+    (r'\)',                                       "')'",        'RPAREN'),
+    (r'\[',                                       "'['",        'LBRACKET'),
+    (r'\]',                                       "']'",        'RBRACKET'),
+    (r':',                                        "':'",        'COLON'),
+    (r'\|',                                       "'|'",        'BAR'),
+    (r'\.',                                       "'.'",        'DOT'),
+    (r',',                                        "','",        'COMMA'),
+    (r'=',                                        "'='",        'ASSIGN'),
     # this is the catch-all pattern, it has to be
     # here do that we can report illegal characters
     # in the input.
-    (r'.',                                                      'MISMATCH'),
+    (r'.',                                        "unknown",    'MISMATCH'),
 ]
 
 # this table specifies token types that are used in the tokenizer
@@ -100,6 +100,26 @@ implicit_token_types = [
     'INTEGER',
     'REAL',
 ]
+
+# A table that given a token type will return the expected value
+# a reverse token specification: given a type compute the value
+token_values = {}
+
+def init_token_values():
+    global token_values
+
+    # grab tokens from token_specs table
+    token_values.update({'INTEGER':'integer value'})
+    token_values.update({'REAL':'real value'})
+    for (_,display,type) in token_specs:
+        token_values.update({type:display})
+
+    # grab tokens from keywords table
+    for k in keywords:
+        token_values.update({keywords[k]:"'"+k+"'"})
+
+def token_lookup(type):
+    return token_values[type]
 
 class Token:
     def __init__(self,type,value,module,lineno):
@@ -118,7 +138,7 @@ def tokenize(code):
     (module, line_num) = state.lineinfo
     # here we create a list of named patterns from the token_specs table
     # the name of the pattern is the token type
-    named_re_list = ['(?P<{}>{})'.format(type,re) for (re,type) in token_specs]
+    named_re_list = ['(?P<{}>{})'.format(type,re) for (re,_,type) in token_specs]
     # create one giant re that describes the token structure of the whole
     # language. we 'or' together all the re's on the named_re_list
     combined_re = '|'.join(named_re_list)
@@ -172,7 +192,6 @@ def tokenize(code):
         elif type == 'MISMATCH':
             if value == '\"':
                 raise ExpectationError(expected='\"', found='EOF')
-
             else:
                 raise ValueError("unexpected character '{}'".format(value))
         # put the token onto the tokens list
@@ -195,9 +214,11 @@ class Lexer:
         # keep a set of all possible token types in our lexer
         # this let's us weed out bad match calls very easily
         self.token_types = \
-            set(type for (_,type) in token_specs) | \
+            set(type for (_,_,type) in token_specs) | \
             set(list(keywords.values())) | \
             set(implicit_token_types)
+        # init token value lookup
+        init_token_values()
 
     def input(self, input_string):
         self.tokens = tokenize(input_string)
@@ -228,7 +249,8 @@ class Lexer:
         if token_type not in self.token_types:
             raise ValueError("unknown token type '{}'".format(token_type))
         elif token_type != self.curr_token.type:
-            raise ExpectationError( found=self.curr_token.type, expected=token_type)
+            raise ExpectationError(found=token_lookup(self.curr_token.type),
+                                   expected=token_lookup(token_type))
         else:
             dbg_print('matching {}'.format(token_type))
             ct = self.curr_token


### PR DESCRIPTION
Introduced the `token_value` table which is essentially a reverse `token_spec` table that given a token type produces a readable representation of the associated token value.  This allows us to improve the error messages generated by the frontend, e.g.,
```
Error: parse.ast: 2: expected RPAREN found COMMA.
```
to
```
Error: parse.ast: 2: expected ')' found ','
```