### PR TITLE
fixes #159 - enable stack traces for uncaught Asteroid exceptions

### DIFF
--- a/asteroid/__init__.py
+++ b/asteroid/__init__.py
@@ -26,7 +26,7 @@ def display_help():
     print(" -p    disable prologue")
     print(" -h    display help")
     print(" -r    disable redundant pattern detector")
-    print(" -e    show full exceptions")
+    print(" -e    show Python exceptions")
 
 def main():
     # defaults for the flags - when the flag is set on the command line

--- a/asteroid/interp.py
+++ b/asteroid/interp.py
@@ -10,7 +10,7 @@ import sys
 from asteroid.globals import *
 from asteroid.support import *
 from asteroid.frontend import Parser
-from asteroid.state import state
+from asteroid.state import state, dump_trace
 from asteroid.walk import walk
 
 # the prologue file is expected to be in the 'modules' folder
@@ -29,7 +29,7 @@ def interp(input_stream,
     try:
         # initialize state
         if initialize_state:
-            state.initialize()
+            state.initialize(input_name)
 
         #lhh
         #print("path[0]: {}".format(sys.path[0]))
@@ -79,28 +79,31 @@ def interp(input_stream,
     #       for 'Exception' unless the exception needs special handling like
     #       'ThrowValue' or 'ReturnValue' etc.
     except ThrowValue as throw_val:
+        dump_trace()
         # handle exceptions using the standard Error constructor
         module, lineno = state.lineinfo
         if throw_val.value[0] == 'apply' and throw_val.value[1][1] == 'Error':
             (APPLY, (ID, id), (APPLY, error_obj, rest)) = throw_val.value
-            print("Error: {}: {}: {}".format(module, lineno, term2string(error_obj)))
+            print("error: {}: {}: {}".format(module, lineno, term2string(error_obj)))
         else:
-            print("Error: {}: {}: unhandled Asteroid exception: {}"
+            print("error: {}: {}: unhandled Asteroid exception: {}"
                   .format(module, lineno, term2string(throw_val.value)))
         # needed for REPL
         if not exceptions:
             sys.exit(1)
 
     except ReturnValue as inst:
+        dump_trace()
         module, lineno = state.lineinfo
-        print("Error: {}: {}: return statement used outside a function environment"
+        print("error: {}: {}: return statement used outside a function environment"
               .format(module, lineno))
         # needed for REPL
         if not exceptions:
             sys.exit(1)
 
     except  KeyboardInterrupt as e:
-        print("Error: keyboard interrupt")
+        dump_trace()
+        print("error: keyboard interrupt")
         # needed for REPL
         if not exceptions:
             sys.exit(1)
@@ -111,14 +114,16 @@ def interp(input_stream,
                 state.symbol_table.dump()
             raise e
         else:
+            dump_trace()
             module, lineno = state.lineinfo
-            print("Error: {}: {}: {}".format(module, lineno, e))
+            print("error: {}: {}: {}".format(module, lineno, e))
             # needed for REPL
             if not exceptions:
                 sys.exit(1)
 
     except BaseException as e:
-        print("Error: {}".format(e))
+        dump_trace()
+        print("error: {}".format(e))
         # needed for REPL
         if not exceptions:
             sys.exit(1)

--- a/asteroid/repl.py
+++ b/asteroid/repl.py
@@ -55,7 +55,7 @@ def run_repl():
         except EOFError:
             print()
             break
-        
+
         """
         Interpretation, multiline input, and exception handling
         """
@@ -63,7 +63,7 @@ def run_repl():
             # Try to interpret the new statement
             interp(line, initialize_state=False, exceptions=True)
 
-            # Try to 
+            # Try to
             line = ""
 
         except ExpectationError as e:
@@ -71,13 +71,13 @@ def run_repl():
             if e.found_EOF:
                 current_prompt = continue_prompt
             else:
-                print(e)
+                print("error: "+str(e))
                 line = ""
                 current_prompt = arrow_prompt
 
         except Exception as e:
             # FIX THIS
-            print(e)
+            print("error: "+str(e))
             line = ""
             current_prompt = arrow_prompt
 

--- a/asteroid/state.py
+++ b/asteroid/state.py
@@ -10,7 +10,7 @@ class State:
     def __init__(self):
         self.initialize()
 
-    def initialize(self):
+    def initialize(self,module="<input>"):
         self.symbol_table = SymTab()
         self.modules = [] # loaded modules
         self.AST = None
@@ -19,10 +19,22 @@ class State:
         self.cond_warning = False # used to indicate if conditional subsumption
                                   # warning has been displayed
         self.eval_redundancy = True
-        self.lineinfo = ("<input>", 1) # tuple: module, lineno
+        self.lineinfo = (module, 1) # tuple: module, lineno
+        # stack of 3-tuples for stack trace of function
+        # calls: (module,lineno,function name)
+        self.trace_stack = [(module,1,"<toplevel>")]
 
 state = State()
 
 def warning(str):
     module, lineno = state.lineinfo
     print("Warning: {}: {}: {}".format(module, lineno, str))
+
+def dump_trace():
+    if len(state.trace_stack) == 1:
+        return
+    else:
+        print("traceback (most recent call last):")
+        for i in range(0,len(state.trace_stack)):
+            (module,lineno,fname) = state.trace_stack[i]
+            print("{}: {}: calling {}".format(module,lineno,fname))

--- a/asteroid/walk.py
+++ b/asteroid/walk.py
@@ -824,6 +824,10 @@ def handle_call(obj_ref, fval, actual_val_args, fname):
     (FUNCTION_VAL, body_list, closure) = fval
     assert_match(FUNCTION_VAL, 'function-val')
 
+    state.trace_stack.append((state.lineinfo[0],
+                              state.lineinfo[1],
+                              fname))
+
     # static scoping for functions
     # Note: we have to do this here because unifying
     # over the body patterns can introduce variable declarations,
@@ -890,6 +894,8 @@ def handle_call(obj_ref, fval, actual_val_args, fname):
     state.lineinfo = old_lineinfo
     state.symbol_table.pop_scope()
     state.symbol_table.set_config(save_symtab)
+
+    state.trace_stack.pop()
 
     return return_value
 


### PR DESCRIPTION
These fixes enable stack trace backs for uncaught Asteroid exceptions.  For example, the 
following program,
```
function divide with (dividend, divisor) do
   return divide2(dividend,divisor).
end

function divide2 with (dividend, divisor) do
   return dividend/divisor.
end

let i = divide(3,0).
```
will give rise to the trace back,
```
traceback (most recent call last):
except.ast: 1: calling <toplevel>
except.ast: 9: calling divide
except.ast: 2: calling divide2
error: except.ast: 6: integer division or modulo by zero
```


