### PR TITLE
fixes for issue #163

### DIFF
--- a/asteroid/test-suites/regression-tests/test085.ast
+++ b/asteroid/test-suites/regression-tests/test085.ast
@@ -7,8 +7,8 @@ structure A with
     data y.
     end 
 
-let a = A(999, (lambda with (self) do return "Hello World!")).
+let a = A(999, (lambda with none do return "Hello World!"+this@x)).
 io @println (a@1()).
 
-assert(a@1() is "Hello World!").
+assert(a@1() is "Hello World!999").
 

--- a/asteroid/walk.py
+++ b/asteroid/walk.py
@@ -1281,8 +1281,25 @@ def apply_exp(node):
         return handle_builtins(node)
 
     # handle function application
+    # retrive the function name from the AST
+    if f[0] in ['function-exp','apply']:
+        # cannot use the function expression as a name,
+        # could be a very complex computation. the apply
+        # node means that the lambda function has to still be
+        # computed.
+        f_name = 'lambda'
+    elif f[0] == 'index':
+        # object member function
+        (INDEX, ix, (ID, f_name)) = f
+        # 'str' is necessary in case we use an index value
+        # instead of a function name -- see regression test test085.ast
+        f_name = "member function " + str(f_name)
+    else:
+        # just a regular function call
+        (ID, f_name) = f
+
+    # evaluate the function expression and the arguments
     f_val = walk(f)
-    f_name = f[1]
     arg_val = walk(arg)
 
     # object member function


### PR DESCRIPTION
The fixes now properly show the stack dump.  In particular it fixes the stack dump for the following programs.  The first one involving member functions,
```
structure A with
   data a.
   data b.
   function divide with none do
      return this@a/this@b.
   end
end

let o = A(1,A(2,0)).
o@b@divide().
```
The second one involving lambda functions,
```
let x = (lambda with i do return i/0) 1.
```
and the third one involving expression that compute lambda values,
```
load system io.

function addc with x do return lambda with y do return x + y end
let a = (addc 1) 1.
io @println a.
assert(a is 2).
```

