### PR TITLE
Extended the REPL to print out expression value

### DIFF
--- a/asteroid/repl.py
+++ b/asteroid/repl.py
@@ -68,13 +68,13 @@ def run_repl():
             line = ""
 
             # Check for return value
-            if function_return_value:
-                # Get the last return value
-                val = function_return_value[-1]
+            if function_return_value[-1]:
+                # Get the last return value (type, value)
+                (_, val) = function_return_value[-1]
 
                 # If it isn't none, print out the value
-                if val:
-                    print(val[1])
+                if val is not None:
+                    print(val)
 
         except ExpectationError as e:
             # If we expected something but found EOF, it's a continue

--- a/asteroid/repl.py
+++ b/asteroid/repl.py
@@ -2,6 +2,7 @@ from asteroid.interp import interp
 from asteroid.version import VERSION
 from asteroid.state import state
 from asteroid.globals import ExpectationError
+from asteroid.walk import function_return_value
 
 from sys import stdin
 import readline
@@ -65,6 +66,15 @@ def run_repl():
 
             # Try to
             line = ""
+
+            # Check for return value
+            if function_return_value:
+                # Get the last return value
+                val = function_return_value[-1]
+
+                # If it isn't none, print out the value
+                if val:
+                    print(val[1])
 
         except ExpectationError as e:
             # If we expected something but found EOF, it's a continue


### PR DESCRIPTION
The REPL now prints out the value, if available, of any expression entered.

Examples:
```
> 1+2
3
> let x = 5.
> x == 6
False
> x == 5
True
> x == 11 or 1 == 1.
True.
> function foo 
.    with x:%string do
.        "Altered " + x.
.    end
> foo("asteroid").
Altered asteroid
> foo("string") + " !"
Altered string !
``` 