### PR TITLE
Stride to step conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Documentation on Asteroid can be found at
 * A Python API allowing the developer to call the Asteroid interpreter from within a Python program and also embed
   Python code in an Asteroid program.
 
-* Eliminated the `step` notation in list comprehensions and replaced it with the `step` notation.
+* Eliminated the `stride` notation in list comprehensions and replaced it with the `step` notation.
 
 * Lots of bug fixes.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Documentation on Asteroid can be found at
 
 * Asteroid now supports its own interactive debugger `adb`.
 
-* Eliminated the `stride` notation in list comprehensions and replaced it with the `step` notation.
+* Eliminated the `step` notation in list comprehensions and replaced it with the `step` notation.
 
 * Lots of bug fixes.
 

--- a/asteroid.vim
+++ b/asteroid.vim
@@ -12,7 +12,7 @@ if exists("b:current_syntax")
 endif
 
 syn keyword basic with end do load let for function structure in is pattern 
-syn keyword basic throw this system data global return to stride if not
+syn keyword basic throw this system data global return to step if not
 syn keyword basic else or and
 
 syn keyword delimeter escape

--- a/asteroid/frontend.py
+++ b/asteroid/frontend.py
@@ -651,18 +651,18 @@ class Parser:
         elif tt == 'TO':
             self.lexer.match('TO')
             v2 = self.exp()
-            if self.lexer.peek().type == 'STRIDE':
-                self.lexer.match('STRIDE')
+            if self.lexer.peek().type == 'STEP':
+                self.lexer.match('STEP')
                 v3 = self.exp()
                 return ('raw-to-list',
                         ('start', v),
                         ('stop', v2),
-                        ('stride', v3))
+                        ('step', v3))
             else:
                 return ('raw-to-list',
                         ('start', v),
                         ('stop', v2),
-                        ('stride', ('integer', '1')))
+                        ('step', ('integer', '1')))
 
         else:
             return v

--- a/asteroid/grammar.txt
+++ b/asteroid/grammar.txt
@@ -91,7 +91,7 @@
         (
            (IS pattern) |
            (IN exp) |               /* exp has to be a list */
-           (TO exp (STRIDE exp)?) |   /* list comprehension */
+           (TO exp (STEP exp)?) |   /* list comprehension */
         )?
 
   logic_exp0

--- a/asteroid/lex.py
+++ b/asteroid/lex.py
@@ -40,7 +40,7 @@ keywords = {
     'pattern'       : 'PATTERN',
     'repeat'        : 'REPEAT',
     'return'        : 'RETURN',
-    'stride'        : 'STRIDE',
+    'step'        : 'STEP',
     'structure'     : 'STRUCTURE',
     'system'        : 'SYSTEM',
     'throw'         : 'THROW',

--- a/asteroid/modules/prologue.ast
+++ b/asteroid/modules/prologue.ast
@@ -93,7 +93,7 @@ function range
   with (start:%integer,stop:%integer) do
     return [start to stop-1].
   with (start:%integer,stop:%integer,inc:%integer) do
-    return [start to stop-1 stride inc].
+    return [start to stop-1 step inc].
   with stop:%integer do
     return [0 to stop-1].
   end

--- a/asteroid/test-suites/action-tests/test073.ast
+++ b/asteroid/test-suites/action-tests/test073.ast
@@ -2,7 +2,7 @@
   load system math.
 
   let a = [20 to 30].
-  let array = a @[1 to a @length()-1 stride 2] .
+  let array = a @[1 to a @length()-1 step 2] .
   io @println array.
 
   assert (array == [21,23,25,27,29]).

--- a/asteroid/test-suites/regression-tests/test044.ast
+++ b/asteroid/test-suites/regression-tests/test044.ast
@@ -1,6 +1,6 @@
 
 load system io.      
 load "util".
-let slice = [4 to 0 stride 1].
+let slice = [4 to 0 step 1].
 io @println slice.
-assert(slice is [4,3,2,1,0]).
+assert(slice is []).

--- a/asteroid/test-suites/regression-tests/test044.ast
+++ b/asteroid/test-suites/regression-tests/test044.ast
@@ -1,6 +1,6 @@
 
 load system io.      
 load "util".
-let slice = [4 to 0 step 1].
+let slice = [4 to 0 step -1].
 io @println slice.
-assert(slice is []).
+assert(slice is [4,3,2,1,0]).

--- a/asteroid/test-suites/regression-tests/test090.ast
+++ b/asteroid/test-suites/regression-tests/test090.ast
@@ -3,6 +3,6 @@ load system io.
 load "util".
 
 let a = [0,1,2,3].
-let b = a@[0 to 3 stride 2].
+let b = a@[0 to 3 step 2].
 io @println b.
 assert (b is [0,2]).

--- a/asteroid/test-suites/regression-tests/test091.ast
+++ b/asteroid/test-suites/regression-tests/test091.ast
@@ -2,7 +2,7 @@
 load system io.
 load "util".
 
-let y = [0 to 10 stride 2].
+let y = [0 to 10 step 2].
 let z = 4 in y.
 io @println z.
 assert z.

--- a/asteroid/test-suites/ug-programs/prgm-011.ast
+++ b/asteroid/test-suites/ug-programs/prgm-011.ast
@@ -1,10 +1,10 @@
     load system io.
 
     -- build a list of odd values
-    let a = [1 to 10 stride 2].  -- list comprehension
+    let a = [1 to 10 step 2].  -- list comprehension
     io @println ("list: " + a).
 
     -- reverse the list using a slice computed as comprehension
-    let slice = [4 to 0 stride 1]. -- list comprehension
+    let slice = [4 to 0 step -1]. -- list comprehension
     let b = a @slice.
     io @println ("reversed list: " + b).

--- a/asteroid/test-suites/ug-programs/prgm-022.ast
+++ b/asteroid/test-suites/ug-programs/prgm-022.ast
@@ -1,5 +1,5 @@
     load system io.
 
-    for i in 0 to 10 stride 2 do
+    for i in 0 to 10 step 2 do
         io @println i.
     end

--- a/asteroid/walk.py
+++ b/asteroid/walk.py
@@ -1501,54 +1501,39 @@ def to_list_exp(node):
     (TOLIST,
      (START, start),
      (STOP, stop),
-     (STRIDE, stride)) = node
+     (STEP, step)) = node
 
     assert_match(TOLIST, 'to-list')
     assert_match(START, 'start')
     assert_match(STOP, 'stop')
-    assert_match(STRIDE, 'stride')
+    assert_match(STEP, 'step')
 
     (START_TYPE, start_val, *_) = walk(start)
     (STOP_TYPE, stop_val, *_) = walk(stop)
-    (STRIDE_TYPE, stride_val, *_) = walk(stride)
+    (STEP_TYPE, step_val, *_) = walk(step)
 
-    if START_TYPE != 'integer' or STOP_TYPE != 'integer' or STRIDE_TYPE != 'integer':
-        raise ValueError("only integer values allowed in start, stop, or stride")
+    if START_TYPE != 'integer' or STOP_TYPE != 'integer' or STEP_TYPE != 'integer':
+        raise ValueError("only integer values allowed in start, stop, or step")
 
     out_list_val = []
 
-    # If our stride val is > 0
-    if int(stride_val) > 0: # generate the list
-        # Get the [i]nitial inde[x] and [e]nd inde[x]
+    if int(step_val) > 0: # generate the list
         ix = int(start_val)
-        ex = int(stop_val)
+        while ix <= int(stop_val):
+            out_list_val.append(('integer', ix))
+            ix += int(step_val)
 
-        # Get the stride_val
-        stride_val = int(stride_val)
+    elif int(step_val) == 0: # error
+        raise ValueError("step size of 0 not supported")
 
-        # Change the direction of the stride value based on the
-        # ends of the range. I.e. 5->1 has an implicit direction
-        # of -1, 1->5 has a direction of +1
-        direction = (1 if ix < ex else -1)
-        stride_val *= direction
-
-        # We need to modify the ending index to acccount for python
-        # ranges. For example, for 1->10 we want range(1, 10 + 1).
-        # Or, for the opposite, we want range(10, 1 - 1) to give
-        # us the full inclusive range. Thus, we can just add our
-        # direction
-        new_ex = ex + direction
-        for i in range(ix, new_ex, stride_val):
-            out_list_val.append( ('integer', i) )
-
-    elif int(stride_val) == 0: # error
-        raise ValueError("stride size of 0 not supported")
-
-    elif int(stride_val) < 0: # generate the list
-        raise ValueError("negative stride sizes are not supported")
+    elif int(step_val) < 0: # generate the list
+        ix = int(start_val)
+        while ix >= int(stop_val):
+            out_list_val.append(('integer', ix))
+            ix += int(step_val)
 
     else:
-        raise ValueError("'{}' not a valid stride value".format(stride_val))
+        raise ValueError("{} not a valid step value".format(step_val))
 
     return ('list', out_list_val)
 

--- a/docs/Asteroid in Action.rst
+++ b/docs/Asteroid in Action.rst
@@ -2141,7 +2141,7 @@ We can use an index vector to accomplish  the same thing,
   load system math.
 
   let a = [20 to 30].
-  let array = a @[1 to a @length()-1 stride 2] .
+  let array = a @[1 to a @length()-1 step 2] .
   io @println array.
 
   assert (array == [21,23,25,27,29]).

--- a/docs/Reference Guide.rst
+++ b/docs/Reference Guide.rst
@@ -464,18 +464,18 @@ Example,
 List Comprehensions
 %%%%%%%%%%%%%%%%%%%
 
-Syntax: ``start_exp TO end_exp (STRIDE exp)?``
+Syntax: ``start_exp TO end_exp (STEP exp)?``
 
 This expression constructs a list starting with an element given by the start expression
-up to the value of the end expression with a given stride.  If the stride expression
-is not given then a stride value of 1 is assumed.  The stride value is always a
-positive value.  The comprehension figures out how to apply the stride value to reach the
+up to the value of the end expression with a given step.  If the step expression
+is not given then a step value of 1 is assumed.  The step value is always a
+positive value.  The comprehension figures out how to apply the step value to reach the
 end value from the start value.  The comprehension can be placed between optional square brackets.
 
 Examples,
 ::
       let [0,1,2,3,4] = 0 to 4.
-      let [0,-2,-4,-6] = [0 to -6 stride 2].
+      let [0,-2,-4,-6] = [0 to -6 step 2].
 
 Function Calls
 %%%%%%%%%%%%%%
@@ -689,7 +689,7 @@ are written in quotes.
         (
            (IS pattern) |
            (IN exp) |               
-           (TO exp (STRIDE exp)?) |   
+           (TO exp (STEP exp)?) |   
         )?
 
   logic_exp0
@@ -762,7 +762,7 @@ Builtin Functions
 * Function ``range`` will compute a list of values depending on the input values:
 
   1. ``(start:%integer,stop:%integer)`` returns list ``[start to stop-1]``.
-  2. ``(start:%integer,stop:%integer,inc:%integer)`` returns list ``[start to stop-1 stride inc]``.
+  2. ``(start:%integer,stop:%integer,inc:%integer)`` returns list ``[start to stop-1 step inc]``.
   3. ``(stop:%integer)`` returns list ``[0 to stop-1]``.
 
 * Function ``getid`` returns the id (physical memory address) of any Asteroid object as an Asteroid integer.

--- a/docs/Reference Guide.txt
+++ b/docs/Reference Guide.txt
@@ -463,14 +463,13 @@ Syntax: ``start_exp TO end_exp (STEP exp)?``
 
 This expression constructs a list starting with an element given by the start expression
 up to the value of the end expression with a given step.  If the step expression
-is not given then a step value of 1 is assumed.  The step value is always a
-positive value.  The comprehension figures out how to apply the step value to reach the
-end value from the start value.  The comprehension can be placed between optional square brackets.
+is not given then a step value of 1 is assumed. The comprehension can be placed between
+optional square brackets.
 
 Examples,
 ::
       let [0,1,2,3,4] = 0 to 4.
-      let [0,-2,-4,-6] = [0 to -6 step 2].
+      let [0,-2,-4,-6] = [0 to -6 step -2].
 
 Function Calls
 %%%%%%%%%%%%%%

--- a/docs/Reference Guide.txt
+++ b/docs/Reference Guide.txt
@@ -459,18 +459,18 @@ Example,
 List Comprehensions
 %%%%%%%%%%%%%%%%%%%
 
-Syntax: ``start_exp TO end_exp (STRIDE exp)?``
+Syntax: ``start_exp TO end_exp (STEP exp)?``
 
 This expression constructs a list starting with an element given by the start expression
-up to the value of the end expression with a given stride.  If the stride expression
-is not given then a stride value of 1 is assumed.  The stride value is always a
-positive value.  The comprehension figures out how to apply the stride value to reach the
+up to the value of the end expression with a given step.  If the step expression
+is not given then a step value of 1 is assumed.  The step value is always a
+positive value.  The comprehension figures out how to apply the step value to reach the
 end value from the start value.  The comprehension can be placed between optional square brackets.
 
 Examples,
 ::
       let [0,1,2,3,4] = 0 to 4.
-      let [0,-2,-4,-6] = [0 to -6 stride 2].
+      let [0,-2,-4,-6] = [0 to -6 step 2].
 
 Function Calls
 %%%%%%%%%%%%%%
@@ -630,7 +630,7 @@ Builtin Functions
 * Function ``range`` will compute a list of values depending on the input values:
 
   1. ``(start:%integer,stop:%integer)`` returns list ``[start to stop-1]``.
-  2. ``(start:%integer,stop:%integer,inc:%integer)`` returns list ``[start to stop-1 stride inc]``.
+  2. ``(start:%integer,stop:%integer,inc:%integer)`` returns list ``[start to stop-1 step inc]``.
   3. ``(stop:%integer)`` returns list ``[0 to stop-1]``.
 
 * Function ``getid`` returns the id (physical memory address) of any Asteroid object as an Asteroid integer.

--- a/docs/User Guide.rst
+++ b/docs/User Guide.rst
@@ -175,16 +175,16 @@ For a comprehensive treatment of available member functions for Asteroid lists p
 
 Besides using the default constructor for lists which consists of the
 square brackets enclosing a list of elements we can use **list comprehensions** to construct lists.  In Asteroid a list comprehension consist of a range specifier together with
-a stride specifier allowing you to generate integer values within that range,
+a step specifier allowing you to generate integer values within that range,
 ::
     load system io.
 
     -- build a list of odd values
-    let a = [1 to 10 stride 2].  -- list comprehension
+    let a = [1 to 10 step 2].  -- list comprehension
     io @println ("list: " + a).
 
     -- reverse the list using a slice computed as comprehension
-    let slice = [4 to 0 stride 1]. -- list comprehension
+    let slice = [4 to 0 step 1]. -- list comprehension
     let b = a @slice.
     io @println ("reversed list: " + b).
 
@@ -408,7 +408,7 @@ As we said, in terms of flow of control statements there are really not a lot of
 ::
     load system io.
 
-    for i in 0 to 10 stride 2 do
+    for i in 0 to 10 step 2 do
         io @println i.
     end
 

--- a/docs/User Guide.txt
+++ b/docs/User Guide.txt
@@ -142,7 +142,7 @@ For a comprehensive treatment of available member functions for Asteroid lists p
 
 Besides using the default constructor for lists which consists of the
 square brackets enclosing a list of elements we can use **list comprehensions** to construct lists.  In Asteroid a list comprehension consist of a range specifier together with
-a stride specifier allowing you to generate integer values within that range,
+a step specifier allowing you to generate integer values within that range,
 ::
 #include "../asteroid/test-suites/ug-programs/prgm-011.ast"
 


### PR DESCRIPTION
In light of #181 this PR reverses the change in syntax and semantics for the stride list comprehension. We are now back to the standard step notation with negative step values.