### PR TITLE
Add pyreadline3 to requirements.txt for installation when platform is Windows

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pandas
 numpy
 matplotlib
+pyreadline3; platform_system == "Windows"


### PR DESCRIPTION
This adds pyreadline3 to requirements.txt. It will only install when the detected platform is Windows. This should fix bug #233.