### PR TITLE
it is no longer possible to match pattern values

### DIFF
--- a/asteroid/test-suites/regression-tests/test130.ast
+++ b/asteroid/test-suites/regression-tests/test130.ast
@@ -1,8 +1,0 @@
--- patterns are just values: we can pattern match and index
-let z = pattern ((p,q),(r,t)).
-let pattern (x,_) = z.
-let y = z@0.
-
-assert((1,2) is %[*x]%).
-assert((1,2) is %[*y]%).
-

--- a/asteroid/test-suites/regression-tests/test131.ast
+++ b/asteroid/test-suites/regression-tests/test131.ast
@@ -1,4 +1,0 @@
--- patterns can always match themselves.
-let z = pattern (p,q).
-assert(z is %[*z]%).
-


### PR DESCRIPTION
it is no longer possible to match on pattern values,
```
let p = pattern %[(x:%integer) if x > 0]%.
let *p = p. <<< this line will fail
```
This was done due to the fact that you cannot pattern-match on computations in the if-clause.