### PR TITLE
Mk load compiler

### DIFF
--- a/asteroid/compiler_tests/testA.ast
+++ b/asteroid/compiler_tests/testA.ast
@@ -1,8 +1,0 @@
-load system compiler.
-load system io.
-
-io @println "Compiler loaded sucessfully!"
-
---compiler@compile
-
---compiler@run

--- a/asteroid/modules/compiler.ast
+++ b/asteroid/modules/compiler.ast
@@ -31,18 +31,33 @@ import subprocess
 
 # list for the future if we want to specifiy rust versions
 valid_compiler_list = ['1.75.0']
+# lowest acceptable version of the compiler
+minimum_version = '1.75.0'
 
 compiler_check_command = subprocess.run('rustc --version', shell=True, capture_output=True, text=True)
 compiler_string = compiler_check_command.stdout
 compiler_error = compiler_check_command.stderr
 
 # fails if no compiler is installed
-assert compiler_error == ''
+# assert compiler_error == ''
+if compiler_error != '':
+    raise ImportError('Rust Compiler not installed try visiting: \'https://www.rust-lang.org/tools/install\'')
 
 # version verification
 compiler_version = compiler_string.split(' ')[1]
+
+min_list = minimum_version.split('.')
+current_list = current_version.split('.')
+if(len(min_list) != len(current_list)):
+    raise ValueError('Version comparison strings dont match')
+else:
+    for (min_val, current_val) in zip(min_list, current_list):
+        if int(current_val) < int(min_val):
+            raise ImportError('Rust Compiler not up to date, try updating by running \'rustup update\'')
+        elif int(current_val) > int(min_val):
+            break
 # fails if the compiler is not the correct version
-assert compiler_version in valid_compiler_list
+# assert compiler_version in valid_compiler_list
 "
 end
 

--- a/asteroid/modules/compiler.ast
+++ b/asteroid/modules/compiler.ast
@@ -41,19 +41,19 @@ compiler_error = compiler_check_command.stderr
 # fails if no compiler is installed
 # assert compiler_error == ''
 if compiler_error != '':
-    raise ImportError('Rust Compiler not installed try visiting: \'https://www.rust-lang.org/tools/install\'')
+    raise ImportError('\nRust Compiler not installed try visiting: \'https://www.rust-lang.org/tools/install\'')
 
 # version verification
 compiler_version = compiler_string.split(' ')[1]
 
 min_list = minimum_version.split('.')
-current_list = current_version.split('.')
+current_list = compiler_version.split('.')
 if(len(min_list) != len(current_list)):
     raise ValueError('Version comparison strings dont match')
 else:
     for (min_val, current_val) in zip(min_list, current_list):
         if int(current_val) < int(min_val):
-            raise ImportError('Rust Compiler not up to date, try updating by running \'rustup update\'')
+            raise ImportError('\nRust Compiler not up to date, {} or higher is required try updating by running \'rustup update\''.format(minimum_version))
         elif int(current_val) > int(min_val):
             break
 # fails if the compiler is not the correct version

--- a/asteroid/modules/compiler.ast
+++ b/asteroid/modules/compiler.ast
@@ -29,8 +29,6 @@ with none do return escape
 "
 import subprocess
 
-# list for the future if we want to specifiy rust versions
-valid_compiler_list = ['1.75.0']
 # lowest acceptable version of the compiler
 minimum_version = '1.75.0'
 
@@ -57,7 +55,6 @@ else:
         elif int(current_val) > int(min_val):
             break
 # fails if the compiler is not the correct version
-# assert compiler_version in valid_compiler_list
 "
 end
 


### PR DESCRIPTION
This feature allows the compiler-module to be loaded in by checking that the proper rust compiler is installed. First the program checks to see if the rust compiler is installed, if it is not it will raise an `importError` and prompt the user to install rust from the rust website. If the rust compiler is installed it will then compare it to a `minimum version` and if it less than that an `importError` will be raised and the user will be told that they need to have atleast  `minimum version`  and will be told they can update by running `rustup update`