### PR TITLE
Milestone 1: Arbitrarily Sized Output from list

### DIFF
--- a/asteroid/mad.py
+++ b/asteroid/mad.py
@@ -292,12 +292,26 @@ class MAD:
       print()
       return START_DEBUGGER
 
-   def _handle_list(self, _):
+   def _handle_list(self, args):
       (file,lineno) = self.interp_state.lineinfo
       self._load_program_text(file)
       pt = self.program_text[file]
       # Length around the current line to display
       length = 4
+      
+      if len(args) > 1:                                  # Too many arguments, reject with an error message
+         print("error: too many arguments")
+         return START_DEBUGGER
+      elif len(args) == 0:                               # No arguments, assume default length and fall through
+         length = length
+      elif args[0] == '*':                               # '*' argument, set length to length of the file and lineno to 0
+         lineno, length = 0, len(pt)
+      elif args[0].isnumeric() and int(args[0]) > 0: # Number greater than 0, cast it and set length to it
+         length = int(args[0])
+      else:                                              # Any other input should be rejected with an error message
+         print("error: expected a number greater than 0 or '*', found '{}'".format(args[0]))
+         return START_DEBUGGER
+      
       # Compute the start and end of listing
       start = (lineno - length) if lineno >= length else 0
       end = lineno + length if lineno < len(pt) - 2 else len(pt)

--- a/asteroid/mad.py
+++ b/asteroid/mad.py
@@ -279,7 +279,7 @@ class MAD:
       print("down\t\t\t- move down one stack frame")
       print("frame\t\t\t- display current stack frame number")
       print("help\t\t\t- display help")
-      print("list\t\t\t- display source code")
+      print("list [<num>|*]\t\t\t- display <num> (default 4) lines of source code, * displays all lines in file")
       print("next\t\t\t- step execution across a nested scope")
       print("print <name>|*\t\t- print contents of <name>, * lists all vars in scope")
       print("quit\t\t\t- quit debugger")
@@ -296,14 +296,12 @@ class MAD:
       (file,lineno) = self.interp_state.lineinfo
       self._load_program_text(file)
       pt = self.program_text[file]
-      # Length around the current line to display
-      length = 4
       
       if len(args) > 1:                                  # Too many arguments, reject with an error message
          print("error: too many arguments")
          return START_DEBUGGER
       elif len(args) == 0:                               # No arguments, assume default length and fall through
-         length = length
+         length = 4
       elif args[0] == '*':                               # '*' argument, set length to length of the file and lineno to 0
          lineno, length = 0, len(pt)
       elif args[0].isnumeric() and int(args[0]) > 0: # Number greater than 0, cast it and set length to it

--- a/docs/MAD.txt
+++ b/docs/MAD.txt
@@ -120,7 +120,7 @@ Here is a table of the available commands in the the debugger,
     down ........................... move down one stack frame
     frame .......................... display current stack frame number
     help ........................... display help
-    list ........................... display source code
+    list [<num>|*].................. display <num> (default 4) lines of source code, * displays all lines in file
     next ........................... step execution across a nested scope
     print <name>|* ................. print contents of <name>, * lists all vars in scope
     quit ........................... quit debugger


### PR DESCRIPTION
- Allow `list` command in MAD to accept an optional argument of either a positive integer greater than 0 or `'*'` to display some number or all lines in a current file respectively
- Updated help command in MAD and MAD.txt documentation to reflect new changes