### PR TITLE
Milestone 2: Allow print to use the @ operator

### DIFF
--- a/asteroid/mad.py
+++ b/asteroid/mad.py
@@ -345,22 +345,28 @@ class MAD:
          print("error: no argument given")
          return False
       
+      # Split any arguments by the '@' character when necessary
       syms = args[0].split('@')
+      # '@' occurs at beginning or end of argument, or multiple `@`s occur next to each other is rejected with an error message
       if '' in syms:
          print("error: any @s must exist between keywords or integers, not adjacent or next to each other")
          return START_DEBUGGER
       
       var_list = self.interp_state.symbol_table.get_curr_scope(scope=self.frame_ix, option="items")
+      # If '*' is the only argument, handle output as normal
       if syms[0] == '*' and len(syms) == 1:
          for (name,val) in var_list:
             print("{}: {}".format(name,term2string(val)))
       else:
+         # Loop through scope and check if any symbols in the scope are the first symbol in the list
          term = None
          for (name, val) in var_list:
             if name == syms[0]:
                term = val
                break
+         # Iterate over remaining terms to find the final symbol
          val = get_tail_term(syms[0], term, syms[1:])
+         # Print the entire argument along with its current symbol if it is found
          if val:
             print("{}: {}".format(args[0], term2string(val)))
       return START_DEBUGGER

--- a/asteroid/mad.py
+++ b/asteroid/mad.py
@@ -281,7 +281,7 @@ class MAD:
       print("help\t\t\t- display help")
       print("list [<num>|*]\t\t\t- display <num> (default 4) lines of source code, * displays all lines in file")
       print("next\t\t\t- step execution across a nested scope")
-      print("print <name>[@<num>|<name>]|*\t\t- print contents of <name>, * lists all vars in scope, specify indices or attributes with @")
+      print("print <name>[@<num>|<name>]+|*\t\t- print contents of <name>, * lists all vars in scope, recursively access (nested) objects with @")
       print("quit\t\t\t- quit debugger")
       print("set [<func>|<line#> [<file>]]\n\t\t\t- set a breakpoint")
       print("stack\t\t\t- display runtime stack")

--- a/asteroid/mad.py
+++ b/asteroid/mad.py
@@ -48,7 +48,7 @@
 ###########################################################################################
 
 from os.path import exists, split, basename
-from asteroid.support import term2string
+from asteroid.support import term2string, get_tail_term
 from asteroid.version import MAD_VERSION
 import copy 
 
@@ -344,16 +344,25 @@ class MAD:
       elif len(args) == 0:
          print("error: no argument given")
          return False
+      
+      syms = args[0].split('@')
+      if '' in syms:
+         print("error: any @s must exist between keywords or integers, not adjacent or next to each other")
+         return START_DEBUGGER
+      
       var_list = self.interp_state.symbol_table.get_curr_scope(scope=self.frame_ix, option="items")
-      if args[0] == '*':
+      if syms[0] == '*' and len(syms) == 1:
          for (name,val) in var_list:
             print("{}: {}".format(name,term2string(val)))
       else:
-         for (name,val) in var_list:
-            if name == args[0]:
-               print("{}: {}".format(args[0],term2string(val)))
-               return START_DEBUGGER
-         print("error: variable {} not found".format(args[0]))
+         term = None
+         for (name, val) in var_list:
+            if name == syms[0]:
+               term = val
+               break
+         val = get_tail_term(syms[0], term, syms[1:])
+         if val:
+            print("{}: {}".format(args[0], term2string(val)))
       return START_DEBUGGER
 
    def _handle_quit(self,_):

--- a/asteroid/mad.py
+++ b/asteroid/mad.py
@@ -281,7 +281,7 @@ class MAD:
       print("help\t\t\t- display help")
       print("list [<num>|*]\t\t\t- display <num> (default 4) lines of source code, * displays all lines in file")
       print("next\t\t\t- step execution across a nested scope")
-      print("print <name>|*\t\t- print contents of <name>, * lists all vars in scope")
+      print("print <name>[@<num>|<name>]|*\t\t- print contents of <name>, * lists all vars in scope, specify indices or attributes with @")
       print("quit\t\t\t- quit debugger")
       print("set [<func>|<line#> [<file>]]\n\t\t\t- set a breakpoint")
       print("stack\t\t\t- display runtime stack")

--- a/docs/Asteroid in Action.rst
+++ b/docs/Asteroid in Action.rst
@@ -1,11 +1,11 @@
 ..
     /******************************************************************
     This is the source file from which the action doc is generated.
-    We use cpp to insert live code snippets into the document.
+    We use pcpp to insert live code snippets into the document.
     In order to generate the action doc run the following command
     on a Unix-like system:
 
-    cpp -w -P "Asteroid in Action.txt" > "Asteroid in Action.rst"
+    python generate_docs.py
 
     ******************************************************************/
 ..

--- a/docs/Asteroid in Action.txt
+++ b/docs/Asteroid in Action.txt
@@ -1,11 +1,11 @@
 ..
     /******************************************************************
     This is the source file from which the action doc is generated.
-    We use cpp to insert live code snippets into the document.
+    We use pcpp to insert live code snippets into the document.
     In order to generate the action doc run the following command
     on a Unix-like system:
 
-    cpp -w -P "Asteroid in Action.txt" > "Asteroid in Action.rst"
+    python generate_docs.py
 
     ******************************************************************/
 #include "header.txt"

--- a/docs/MAD.rst
+++ b/docs/MAD.rst
@@ -122,9 +122,9 @@ Here is a table of the available commands in the the debugger,
     down ........................... move down one stack frame
     frame .......................... display current stack frame number
     help ........................... display help
-    list ........................... display source code
+    list [<num>|*].................. display <num> (default 4) lines of source code, * displays all lines in file
     next ........................... step execution across a nested scope
-    print <name>|* ................. print contents of <name>, * lists all vars in scope
+    print <name>[@<num>|<name>]+|* . print contents of <name>, * lists all vars in scope, recursively access (nested) objects with @
     quit ........................... quit debugger
     stack .......................... display runtime stack
     set [<func>|<line#> [<file>]] .. set a breakpoint
@@ -134,8 +134,8 @@ Here is a table of the available commands in the the debugger,
     where .......................... print current program line
 
 The or bar ``|`` means different options as arguments to the commands. Anything between
-square brackets is optional.  Anything appearing in angle brackets are actual values.
-For example, ``print <name>`` means we want to examine the value of an actual variable, e.g.
+square brackets is optional. The plus symbol ``+`` means at least one of the preceding symbols must be present.
+Anything appearing in angle brackets are actual values. For example, ``print <name>`` means we want to examine the value of an actual variable, e.g.
 ::
     print n
 

--- a/docs/MAD.rst
+++ b/docs/MAD.rst
@@ -1,11 +1,11 @@
 ..
     /******************************************************************
     This is the source file from which the action doc is generated.
-    We use cpp to insert live code snippets into the document.
+    We use pcpp to insert live code snippets into the document.
     In order to generate the action doc run the following command
     on a Unix-like system:
 
-    cpp -w -P "MAD.txt" > "MAD.rst"
+    python generate_docs.py
 
     ******************************************************************/
 ..

--- a/docs/MAD.txt
+++ b/docs/MAD.txt
@@ -132,8 +132,8 @@ Here is a table of the available commands in the the debugger,
     where .......................... print current program line
 
 The or bar ``|`` means different options as arguments to the commands. Anything between
-square brackets is optional.  Anything appearing in angle brackets are actual values. 
-For example, ``print <name>`` means we want to examine the value of an actual variable, e.g.
+square brackets is optional. The plus symbol ``+`` means at least one of the preceding symbols must be present.
+Anything appearing in angle brackets are actual values. For example, ``print <name>`` means we want to examine the value of an actual variable, e.g.
 ::
     print n
 

--- a/docs/MAD.txt
+++ b/docs/MAD.txt
@@ -122,7 +122,7 @@ Here is a table of the available commands in the the debugger,
     help ........................... display help
     list [<num>|*].................. display <num> (default 4) lines of source code, * displays all lines in file
     next ........................... step execution across a nested scope
-    print <name>|* ................. print contents of <name>, * lists all vars in scope
+    print <name>[@<num>|<name>]|* .. print contents of <name>, * lists all vars in scope, specify indices or attributes with @
     quit ........................... quit debugger
     stack .......................... display runtime stack
     set [<func>|<line#> [<file>]] .. set a breakpoint

--- a/docs/MAD.txt
+++ b/docs/MAD.txt
@@ -122,7 +122,7 @@ Here is a table of the available commands in the the debugger,
     help ........................... display help
     list [<num>|*].................. display <num> (default 4) lines of source code, * displays all lines in file
     next ........................... step execution across a nested scope
-    print <name>[@<num>|<name>]|* .. print contents of <name>, * lists all vars in scope, specify indices or attributes with @
+    print <name>[@<num>|<name>]+|* . print contents of <name>, * lists all vars in scope, recursively access (nested) objects with @
     quit ........................... quit debugger
     stack .......................... display runtime stack
     set [<func>|<line#> [<file>]] .. set a breakpoint

--- a/docs/MAD.txt
+++ b/docs/MAD.txt
@@ -1,11 +1,11 @@
 ..
     /******************************************************************
     This is the source file from which the action doc is generated.
-    We use cpp to insert live code snippets into the document.
+    We use pcpp to insert live code snippets into the document.
     In order to generate the action doc run the following command
     on a Unix-like system:
 
-    cpp -w -P "MAD.txt" > "MAD.rst"
+    python generate_docs.py
 
     ******************************************************************/
 

--- a/docs/Quickstart Tutorial.rst
+++ b/docs/Quickstart Tutorial.rst
@@ -1,12 +1,12 @@
 ..
    /******************************************************************
    This is the source file from which the reference guide is
-   generated.  We use cpp to insert live code snippets into the
+   generated.  We use pcpp to insert live code snippets into the
    document. In order to generate the reference guide run the
    following command on a Unix-like system in the directory of
    this doc:
 
-   bash generate_docs
+   python generate_docs.py
 
    ******************************************************************/
 ..

--- a/docs/Quickstart Tutorial.txt
+++ b/docs/Quickstart Tutorial.txt
@@ -1,12 +1,12 @@
 ..
    /******************************************************************
    This is the source file from which the reference guide is
-   generated.  We use cpp to insert live code snippets into the
+   generated.  We use pcpp to insert live code snippets into the
    document. In order to generate the reference guide run the
    following command on a Unix-like system in the directory of
    this doc:
 
-   bash generate_docs
+   python generate_docs.py
 
    ******************************************************************/
 

--- a/docs/Reference Guide.rst
+++ b/docs/Reference Guide.rst
@@ -938,7 +938,7 @@ list **@length** ()
       Returns the number of elements within the list.
 
 list **@map** f:%function
-      Applies the function f to each element of the list in place. The modified list is returned.
+      Returns a new list formed by applying the function f to each element of the list. The original list is unchanged.
 
 list **@member** item
       Returns true only if item exists on the list.


### PR DESCRIPTION
- Allow accessing of specific data members of structures or indices of lists, tuples, and strings
- Correctly handle malformed input (i.e. `@foo`, `bar@` `bar@@foo`)
- Prohibit indexing into structures or accessing data members on anything other than a structure