### PR TITLE
Milestone 4: Add symbol information to stack and trace

### DIFF
--- a/asteroid/mad.py
+++ b/asteroid/mad.py
@@ -474,16 +474,16 @@ class MAD:
          if not args[0].isnumeric():
             print("error: invalid argument '{}', must be some positive integer".format(args[0]))
             return START_DEBUGGER
-         start, end = 0, int(args[0])
+         start, end = self.frame_ix, self.frame_ix + int(args[0])
       else:
-         start, end = 0, len(trace)
+         start, end = self.frame_ix, len(trace)
       
       if end > len(trace):
          print("error: range of stack frames ({}, {}) must not exceed number of existing frames ({})".format(start, end, len(trace)))
          return START_DEBUGGER
       
       print("Runtime stack trace (most recent call first):")
-      for i in range(self.frame_ix + start, end):
+      for i in range(start, end):
          (module, lineno, fname) = trace[i]
          print("frame #{}: {} @{}".format(i, module, fname))
       return START_DEBUGGER

--- a/docs/MAD.rst
+++ b/docs/MAD.rst
@@ -129,7 +129,7 @@ Here is a table of the available commands in the the debugger,
     stack [<num>|* [-v]]................ display runtime stack, list all items in specific frame with an index or all frames with '*', '-v' toggles verbose printing
     set [<func>|<line#> [<file>]] ...... set a breakpoint
     step ............................... step to next executable statement
-    trace [<num>|* [-v]]................ display runtime stack, list all items in specific frame with an index or all frames with '*', '-v' toggles verbose printing
+    trace [<num> [<num>]]............... display runtime stack trace, can specify either the first n frames or all of the frames between the start and end
     up ................................. move up one stack frame
     where .............................. print current program line
 

--- a/docs/MAD.rst
+++ b/docs/MAD.rst
@@ -126,10 +126,10 @@ Here is a table of the available commands in the the debugger,
     next ............................... step execution across a nested scope
     print <name>[@<num>|<name>]+|* [-v]. print contents of <name>, * lists all vars in scope, recursively access (nested) objects with @, '-v' enables verbose printing of nested data
     quit ............................... quit debugger
-    stack .............................. display runtime stack
+    stack [<num>|* [-v]]................ display runtime stack, list all items in specific frame with an index or all frames with '*', '-v' toggles verbose printing
     set [<func>|<line#> [<file>]] ...... set a breakpoint
     step ............................... step to next executable statement
-    trace .............................. display runtime stack
+    trace [<num>|* [-v]]................ display runtime stack, list all items in specific frame with an index or all frames with '*', '-v' toggles verbose printing
     up ................................. move up one stack frame
     where .............................. print current program line
 

--- a/docs/MAD.txt
+++ b/docs/MAD.txt
@@ -124,10 +124,10 @@ Here is a table of the available commands in the the debugger,
     next ............................... step execution across a nested scope
     print <name>[@<num>|<name>]+|* [-v]. print contents of <name>, * lists all vars in scope, recursively access (nested) objects with @, '-v' enables verbose printing of nested data
     quit ............................... quit debugger
-    stack .............................. display runtime stack
+    stack [<num>|* [-v]]................ display runtime stack, list all items in specific frame with an index or all frames with '*', '-v' toggles verbose printing
     set [<func>|<line#> [<file>]] ...... set a breakpoint
     step ............................... step to next executable statement
-    trace .............................. display runtime stack
+    trace [<num>|* [-v]]................ display runtime stack, list all items in specific frame with an index or all frames with '*', '-v' toggles verbose printing
     up ................................. move up one stack frame
     where .............................. print current program line
 

--- a/docs/MAD.txt
+++ b/docs/MAD.txt
@@ -127,7 +127,7 @@ Here is a table of the available commands in the the debugger,
     stack [<num>|* [-v]]................ display runtime stack, list all items in specific frame with an index or all frames with '*', '-v' toggles verbose printing
     set [<func>|<line#> [<file>]] ...... set a breakpoint
     step ............................... step to next executable statement
-    trace [<num>|* [-v]]................ display runtime stack, list all items in specific frame with an index or all frames with '*', '-v' toggles verbose printing
+    trace [<num> [<num>]]............... display runtime stack trace, can specify either the first n frames or all of the frames between the start and end
     up ................................. move up one stack frame
     where .............................. print current program line
 


### PR DESCRIPTION
- Allow users to print all of the symbols in a particular scope by specifying either a frame index or `*` to print all of the symbols in a running program
- Allow users to toggle verbose output like `print` with the `-v` flag.
- Allow `trace` to print a range of stack frames by specifying either a number or range of frames as optional arguments
- Arguments to `trace` behave semantically similar to Python `range()`