### PR TITLE
Mk run method

### DIFF
--- a/asteroid/modules/compiler.ast
+++ b/asteroid/modules/compiler.ast
@@ -56,9 +56,30 @@ function run
 ------------------------------------------------------------------
 with module:%string do
     -- code to run module without parameters
-    let rootpath = __get_path().
-    let exe_path = rootpath + "/compiler/exe/" + module.
-    io@println(exe_path).
+    let comp_path = __get_path().
+    let (rootpath, my_base) = os@split(comp_path).
+    -- io@println(os@platform).
+    if os@platform is "win32" do
+        let exe_name = module + ".exe".
+    else
+        let exe_name = module.
+    end.
+    --     (lone_name, extension) = os@splitext(module).
+    let original_directory = os@getdir().
+    let file_status = os@isfile(rootpath + "/compiler/exe/" + exe_name).
+    -- assert file_status.
+    if not file_status do
+        -- throw Exception("FileNotFound", "input module was not found, file name must not include extension").
+        try
+            throw Exception("FileNotFound", "Module was not found").
+        catch Exception("FileNotFound", message) do
+            io@println(message).
+        end
+    end
+    os@chdir(rootpath + "/compiler/exe").
+    -- io@println(os@getdir()).
+    os@syscmd(exe_name).
+    os@chdir(original_directory).
 -- with (module:%string, params:%list) do
 --     -- code to run module with parameters
 end

--- a/asteroid/modules/compiler.ast
+++ b/asteroid/modules/compiler.ast
@@ -51,14 +51,17 @@ os@chdir(dir_str).
 -- io@println(os@getdir()).
 end
 
--- ------------------------------------------------------------------
--- function run
--- ------------------------------------------------------------------
--- with module:%string do
---     -- code to run module without parameters
+------------------------------------------------------------------
+function run
+------------------------------------------------------------------
+with module:%string do
+    -- code to run module without parameters
+    let rootpath = __get_path().
+    let exe_path = rootpath + "/compiler/exe/" + module.
+    io@println(exe_path).
 -- with (module:%string, params:%list) do
 --     -- code to run module with parameters
--- end
+end
 
 ------------------------------------------------------------------
 function __assert_compiler

--- a/asteroid/modules/compiler.ast
+++ b/asteroid/modules/compiler.ast
@@ -58,27 +58,27 @@ with module:%string do
     -- code to run module without parameters
     let comp_path = __get_path().
     let (rootpath, my_base) = os@split(comp_path).
-    -- io@println(os@platform).
+    --checks if the os is a windows platform and append a '.exe' if it is
     if os@platform is "win32" do
         let exe_name = module + ".exe".
     else
         let exe_name = module.
     end.
-    --     (lone_name, extension) = os@splitext(module).
     let original_directory = os@getdir().
+    -- checks if the specified file exists and thows an error if it doesn't
     let file_status = os@isfile(rootpath + "/compiler/exe/" + exe_name).
-    -- assert file_status.
     if not file_status do
-        -- throw Exception("FileNotFound", "input module was not found, file name must not include extension").
         try
             throw Exception("FileNotFound", "Module was not found").
         catch Exception("FileNotFound", message) do
             io@println(message).
         end
     end
+    -- changes the working directory to the one that holds the executables
     os@chdir(rootpath + "/compiler/exe").
-    -- io@println(os@getdir()).
+    -- runs the executable (without arguments)
     os@syscmd(exe_name).
+    -- changes the directory back to normal
     os@chdir(original_directory).
 -- with (module:%string, params:%list) do
 --     -- code to run module with parameters

--- a/asteroid/modules/compiler.ast
+++ b/asteroid/modules/compiler.ast
@@ -56,6 +56,7 @@ function run
 ------------------------------------------------------------------
 with module:%string do
     -- code to run module without parameters
+    -- takes the name of the executable (no extensions) and runs it without parameters
     let comp_path = __get_path().
     let (rootpath, my_base) = os@split(comp_path).
     --checks if the os is a windows platform and append a '.exe' if it is


### PR DESCRIPTION
The `compiler@run` method will take the name of an executable (without an extension) and run it without arguments. The program will check which os is being run and if it detects windows it will append `.exe` to the file name. then it will check that the file exists and will throw a `FileNotFound` exception if it is not found in the exe directory. Then the working directory is changed to the exe directory, where the asteroid executables are stored, the executable is run (without arguments) then the current working directory is changed to the original working directory.