### PR TITLE
Milestone 4: running with parameters

### DIFF
--- a/asteroid/modules/compiler.ast
+++ b/asteroid/modules/compiler.ast
@@ -30,18 +30,74 @@ param_list = state.symbol_table.lookup_sym('params')
 param_str = ''
 for p in param_list[1]:
     param_str += ' '
-    param_str += str(p[1])
+    if p[0] == 'string':
+        param_str += str(p[1])
+    else:
+        print('found_str')
+        param_str += ('\"' + str(p[1]) + '\"')
 
 __retval__ = ('string', param_str)
 "
 end
 
--- ------------------------------------------------------------------
--- function __convert_tuple
--- ------------------------------------------------------------------
--- with tuple:%string do 
---     if tuple@0 != '('
--- end
+------------------------------------------------------------------
+function __unpack_tuples
+------------------------------------------------------------------
+with params:%tuple do
+    let out_str = "".
+    for p in params do
+        if __is_tuple(p) do
+            let out_str = out_str + __unpack_tuples(p).
+        else do
+            let out_str = out_str + " \"" + tostring(p) + "\"".
+        end
+    end
+    return out_str.
+
+end
+
+------------------------------------------------------------------
+function __is_tuple
+------------------------------------------------------------------
+with item do return escape
+"
+global __retval__
+
+item_val = state.symbol_table.lookup_sym('item')
+
+if item_val[0] == 'tuple':
+    __retval__ = ('boolean', True)
+else:
+    __retval__ = ('boolean', False)
+
+"
+end
+
+------------------------------------------------------------------
+function __make_param_str
+------------------------------------------------------------------
+with params:%list do 
+    let param_str = "".
+    let odd_str = "".
+    let count = 0.
+    for p in params do
+        -- if count % 2 == 0 do
+        --     let param_str = odd_str + "\"" + toString(p) + "\"".
+        -- else do
+        --     let odd_str = param_str + "\"" + toString(p) + "\"".
+        -- end
+        -- let count += 1.
+        if __is_tuple(p) do
+            let param_str = param_str + __unpack_tuples(p).
+        else do
+            let param_str = param_str + " \"" + tostring(p) + "\"".
+        end
+    end
+    return param_str
+    -- for p in params do
+    --     io@println(p)
+    -- end
+end
 
 ------------------------------------------------------------------
 function compile
@@ -107,9 +163,11 @@ with module:%string do
     os@syscmd(exe_name).
     -- changes the directory back to normal
     os@chdir(original_directory).
+
+-- if parameters are provided
 with (module:%string, params:%list) do
 
-    let param_str = __list_to_string(params).
+    let param_str = __make_param_str(params).
     -- io@println(param_str).
     -- io@println("two args").
 -- code to run module without parameters
@@ -134,7 +192,7 @@ with (module:%string, params:%list) do
     end
     -- changes the working directory to the one that holds the executables
     os@chdir(rootpath + "/compiler/exe").
-    -- runs the executable (without arguments)
+    -- runs the executable (with arguments)
     os@syscmd(exe_name + param_str).
     -- changes the directory back to normal
     os@chdir(original_directory).

--- a/asteroid/modules/compiler.ast
+++ b/asteroid/modules/compiler.ast
@@ -19,28 +19,6 @@ __retval__ = ('string', sys.path[0])
 end
 
 ------------------------------------------------------------------
-function __list_to_string
-------------------------------------------------------------------
--- Returns the sum of a list or tuple
-with params:%list do return escape
-"
-global __retval__
-
-param_list = state.symbol_table.lookup_sym('params')
-param_str = ''
-for p in param_list[1]:
-    param_str += ' '
-    if p[0] == 'string':
-        param_str += str(p[1])
-    else:
-        print('found_str')
-        param_str += ('\"' + str(p[1]) + '\"')
-
-__retval__ = ('string', param_str)
-"
-end
-
-------------------------------------------------------------------
 function __unpack_tuples
 ------------------------------------------------------------------
 with params:%tuple do
@@ -81,12 +59,6 @@ with params:%list do
     let odd_str = "".
     let count = 0.
     for p in params do
-        -- if count % 2 == 0 do
-        --     let param_str = odd_str + "\"" + toString(p) + "\"".
-        -- else do
-        --     let odd_str = param_str + "\"" + toString(p) + "\"".
-        -- end
-        -- let count += 1.
         if __is_tuple(p) do
             let param_str = param_str + __unpack_tuples(p).
         else do
@@ -94,9 +66,6 @@ with params:%list do
         end
     end
     return param_str
-    -- for p in params do
-    --     io@println(p)
-    -- end
 end
 
 ------------------------------------------------------------------

--- a/asteroid/modules/compiler.ast
+++ b/asteroid/modules/compiler.ast
@@ -18,6 +18,14 @@ __retval__ = ('string', sys.path[0])
 "
 end
 
+-- ------------------------------------------------------------------
+-- function __convert_tuple
+-- ------------------------------------------------------------------
+-- with tuple:%string do 
+--     if tuple@0 != '('
+-- end
+
+------------------------------------------------------------------
 function compile
 ------------------------------------------------------------------
 with module:%string do
@@ -54,14 +62,14 @@ end
 ------------------------------------------------------------------
 function run
 ------------------------------------------------------------------
-with (module:%string, arguments:%string) do
+with module:%string do
     -- code to run module without parameters
     -- takes the name of the executable (no extensions) and runs it without parameters
     let comp_path = __get_path().
     let (rootpath, my_base) = os@split(comp_path).
     --checks if the os is a windows platform and append a '.exe' if it is
     if os@platform is "win32" do
-        let exe_name = module + ".exe" + " " + arguments.
+        let exe_name = module + ".exe".
     else
         let exe_name = module.
     end.
@@ -81,7 +89,33 @@ with (module:%string, arguments:%string) do
     os@syscmd(exe_name).
     -- changes the directory back to normal
     os@chdir(original_directory).
--- with (module:%string, params:%list) do
+with (module:%string, params:%list) do
+-- code to run module without parameters
+    -- takes the name of the executable (no extensions) and runs it without parameters
+    let comp_path = __get_path().
+    let (rootpath, my_base) = os@split(comp_path).
+    --checks if the os is a windows platform and append a '.exe' if it is
+    if os@platform is "win32" do
+        let exe_name = module + ".exe".
+    else
+        let exe_name = module.
+    end.
+    let original_directory = os@getdir().
+    -- checks if the specified file exists and thows an error if it doesn't
+    let file_status = os@isfile(rootpath + "/compiler/exe/" + exe_name).
+    if not file_status do
+        try
+            throw Exception("FileNotFound", "Module was not found").
+        catch Exception("FileNotFound", message) do
+            io@println(message).
+        end
+    end
+    -- changes the working directory to the one that holds the executables
+    os@chdir(rootpath + "/compiler/exe").
+    -- runs the executable (without arguments)
+    os@syscmd(exe_name).
+    -- changes the directory back to normal
+    os@chdir(original_directory).
 --     -- code to run module with parameters
 end
 

--- a/asteroid/modules/compiler.ast
+++ b/asteroid/modules/compiler.ast
@@ -18,6 +18,24 @@ __retval__ = ('string', sys.path[0])
 "
 end
 
+------------------------------------------------------------------
+function __list_to_string
+------------------------------------------------------------------
+-- Returns the sum of a list or tuple
+with params:%list do return escape
+"
+global __retval__
+
+param_list = state.symbol_table.lookup_sym('params')
+param_str = ''
+for p in param_list[1]:
+    param_str += ' '
+    param_str += str(p[1])
+
+__retval__ = ('string', param_str)
+"
+end
+
 -- ------------------------------------------------------------------
 -- function __convert_tuple
 -- ------------------------------------------------------------------
@@ -90,6 +108,10 @@ with module:%string do
     -- changes the directory back to normal
     os@chdir(original_directory).
 with (module:%string, params:%list) do
+
+    let param_str = __list_to_string(params).
+    -- io@println(param_str).
+    -- io@println("two args").
 -- code to run module without parameters
     -- takes the name of the executable (no extensions) and runs it without parameters
     let comp_path = __get_path().
@@ -113,7 +135,7 @@ with (module:%string, params:%list) do
     -- changes the working directory to the one that holds the executables
     os@chdir(rootpath + "/compiler/exe").
     -- runs the executable (without arguments)
-    os@syscmd(exe_name).
+    os@syscmd(exe_name + param_str).
     -- changes the directory back to normal
     os@chdir(original_directory).
 --     -- code to run module with parameters

--- a/asteroid/modules/compiler.ast
+++ b/asteroid/modules/compiler.ast
@@ -54,14 +54,14 @@ end
 ------------------------------------------------------------------
 function run
 ------------------------------------------------------------------
-with module:%string do
+with (module:%string, arguments:%string) do
     -- code to run module without parameters
     -- takes the name of the executable (no extensions) and runs it without parameters
     let comp_path = __get_path().
     let (rootpath, my_base) = os@split(comp_path).
     --checks if the os is a windows platform and append a '.exe' if it is
     if os@platform is "win32" do
-        let exe_name = module + ".exe".
+        let exe_name = module + ".exe" + " " + arguments.
     else
         let exe_name = module.
     end.


### PR DESCRIPTION
The `compiler@run` method has been modified to accept an optional list of any arguments that need to be passed to the executable, it will recognize a string with a space as a single string. It will also "unpack tuples" ie it will take the values out of the tuple and put them into the executable as lone values, this even works for tuples within tuples, lists will not be unpacked, including tuples within lists.