### PR TITLE
Refined features of tab completion in repl.py

### DIFF
--- a/asteroid/lex.py
+++ b/asteroid/lex.py
@@ -7,7 +7,7 @@
 import re
 
 from asteroid.state import state, warning
-from asteroid.globals import ExpectationError
+from asteroid.globals import ExpectationError, builtins
 
 # table that specifies the token value and type for keywords
 keywords = {
@@ -132,7 +132,7 @@ def token_lookup(type):
 #does not contain duplicates and is sorted alphanumerically.
 def get_indentifiers() -> list[str]:
     #A set is used to only have unique elements
-    ids = set()
+    ids = builtins
     for name in keywords:
         ids.add(name)
     
@@ -154,6 +154,11 @@ def get_indentifiers() -> list[str]:
 def get_indentifiers_by_prefix(prefix: str) -> list[str]:
     #A set is used to only have unique elements
     ids = set()
+    
+    for name in builtins:
+        if name.startswith(prefix):
+            ids.add(name)
+            
     for name in keywords:
         if name.startswith(prefix):
             ids.add(name)

--- a/asteroid/lex.py
+++ b/asteroid/lex.py
@@ -9,12 +9,6 @@ import re
 from asteroid.state import state, warning
 from asteroid.globals import ExpectationError, builtins
 
-repl_use_autocompletion = True
-
-def set_repl_autocomplete(flag: bool):
-    global repl_use_autocompletion
-    repl_use_autocompletion = flag
-
 # table that specifies the token value and type for keywords
 keywords = {
 #   value:          type:

--- a/asteroid/lex.py
+++ b/asteroid/lex.py
@@ -130,7 +130,7 @@ def token_lookup(type):
 #The pool of identifiers includes both user-defined data
 #and keywords defined by the language. The list of identifiers
 #does not contain duplicates and is sorted alphanumerically.
-def get_indentifiers() -> list[str]:
+def get_indentifiers():
     #A set is used to only have unique elements
     ids = builtins
     for name in keywords:
@@ -151,7 +151,7 @@ def get_indentifiers() -> list[str]:
 #The pool of identifiers includes both user-defined data
 #and keywords defined by the language. The list of identifiers
 #does not contain duplicates and is sorted alphanumerically.
-def get_indentifiers_by_prefix(prefix: str) -> list[str]:
+def get_indentifiers_by_prefix(prefix):
     #A set is used to only have unique elements
     ids = set()
     
@@ -178,7 +178,7 @@ def get_indentifiers_by_prefix(prefix: str) -> list[str]:
 #the associated data type, which can be either an object, module or struct. If
 #the identifier given is not for one of the mentioned data types, it will return
 #None
-def get_member_identifiers(identifier: str) -> list[str]|None:
+def get_member_identifiers(identifier):
     if identifier in state.symbol_table.global_scope.keys():
         id_type = state.symbol_table.global_scope[identifier][0]
         if id_type == 'object':

--- a/asteroid/lex.py
+++ b/asteroid/lex.py
@@ -169,6 +169,24 @@ def get_indentifiers_by_prefix(prefix: str) -> list[str]:
     
     return ids
 
+#Given an identifier, it will return a list of identifiers indentifying members of
+#the associated data type, which can be either an object, module or struct. If
+#the identifier given is not for one of the mentioned data types, it will return
+#None
+def get_member_identifiers(identifier: str) -> list[str]|None:
+    if identifier in state.symbol_table.global_scope.keys():
+        id_type = state.symbol_table.global_scope[identifier][0]
+        if id_type == 'object':
+            return state.symbol_table.global_scope[identifier][2][1][1]
+        elif id_type == 'module':
+            return state.symbol_table.global_scope[identifier][-1][-1][0][0].keys()
+        elif id_type == 'struct':
+            return state.symbol_table.global_scope[identifier][1][1][1]
+        else:
+            return None
+    else:
+        return None
+
 class Token:
     def __init__(self,type,value,module,lineno):
         self.type = type

--- a/asteroid/lex.py
+++ b/asteroid/lex.py
@@ -184,7 +184,7 @@ def get_member_identifiers(identifier: str) -> list[str]|None:
         if id_type == 'object':
             return state.symbol_table.global_scope[identifier][2][1][1]
         elif id_type == 'module':
-            return state.symbol_table.global_scope[identifier][-1][-1][0][0].keys()
+            return list(state.symbol_table.global_scope[identifier][-1][-1][0][0].keys())
         elif id_type == 'struct':
             return state.symbol_table.global_scope[identifier][1][1][1]
         else:

--- a/asteroid/lex.py
+++ b/asteroid/lex.py
@@ -14,7 +14,6 @@ repl_use_autocompletion = True
 def set_repl_autocomplete(flag: bool):
     global repl_use_autocompletion
     repl_use_autocompletion = flag
-    _ = 0
 
 # table that specifies the token value and type for keywords
 keywords = {

--- a/asteroid/modules/prologue.ast
+++ b/asteroid/modules/prologue.ast
@@ -973,21 +973,3 @@ with none do
                 @reverse()
                 @join("").
 end
-
-------------------------------------------------------------------
---Repl autocompletion toggle
-------------------------------------------------------------------
-escape
-"
-import os
-import sys
- 
-file_path = os.path.dirname(os.path.abspath( __file__ ))
-os.chdir(file_path)
-(parent_dir,_) = os.path.split(file_path)
-sys.path.append(parent_dir)
-
-from lex import set_repl_autocomplete
-
-set_repl_autocomplete(True)
-"

--- a/asteroid/modules/prologue.ast
+++ b/asteroid/modules/prologue.ast
@@ -989,5 +989,5 @@ sys.path.append(parent_dir)
 
 from lex import set_repl_autocomplete
 
-set_repl_autocomplete(False)
+set_repl_autocomplete(True)
 "

--- a/asteroid/modules/prologue.ast
+++ b/asteroid/modules/prologue.ast
@@ -973,3 +973,21 @@ with none do
                 @reverse()
                 @join("").
 end
+
+------------------------------------------------------------------
+--Repl autocompletion toggle
+------------------------------------------------------------------
+escape
+"
+import os
+import sys
+ 
+file_path = os.path.dirname(os.path.abspath( __file__ ))
+os.chdir(file_path)
+(parent_dir,_) = os.path.split(file_path)
+sys.path.append(parent_dir)
+
+from lex import set_repl_autocomplete
+
+set_repl_autocomplete(False)
+"

--- a/asteroid/repl.py
+++ b/asteroid/repl.py
@@ -10,8 +10,8 @@ from asteroid.state import state
 from asteroid.globals import ExpectationError
 from asteroid.walk import function_return_value
 from asteroid.support import term2string
-from asteroid.lex import get_indentifiers
-from asteroid.lex import get_member_identifiers
+from lex import get_indentifiers
+from lex import get_member_identifiers
 from sys import stdin,exit
 
 import readline
@@ -60,7 +60,7 @@ def completion_function(text, state):
             interp("",
                     initialize_state=False,
                     redundancy=False,
-                    prologue=False,
+                    prologue=True,
                     functional_mode=False,
                     exceptions=True)
             identifiers = get_indentifiers()
@@ -243,4 +243,4 @@ def run_repl(redundancy, functional_mode):
             current_prompt = arrow_prompt
 
 if __name__ == "__main__":
-    run_repl(False, False)
+    repl(True, redundancy=False, prologue=True, functional_mode=False)

--- a/asteroid/repl.py
+++ b/asteroid/repl.py
@@ -4,13 +4,13 @@
 # (c) University of Rhode Island
 ###########################################################################################
 
-from interp import interp, load_prologue
+from asteroid.interp import interp, load_prologue
 from asteroid.version import VERSION
 from asteroid.state import state
 from asteroid.globals import ExpectationError
 from asteroid.walk import function_return_value
 from asteroid.support import term2string
-from lex import get_indentifiers, get_member_identifiers, repl_use_autocompletion
+from asteroid.lex import get_indentifiers, get_member_identifiers, repl_use_autocompletion
 from sys import stdin,exit
 import readline
 import re

--- a/asteroid/repl.py
+++ b/asteroid/repl.py
@@ -10,7 +10,7 @@ from asteroid.state import state
 from asteroid.globals import ExpectationError
 from asteroid.walk import function_return_value
 from asteroid.support import term2string
-from asteroid.lex import get_indentifiers, get_member_identifiers, repl_use_autocompletion
+from asteroid.lex import get_indentifiers, get_member_identifiers
 from sys import stdin,exit
 import readline
 import re

--- a/asteroid/repl.py
+++ b/asteroid/repl.py
@@ -20,6 +20,9 @@ prefix = ""
 last_completion = ""
 last_index = 0
 
+#Change this flag to False to disable autocompletion
+repl_use_autocompletion = True
+
 def repl(new=True, redundancy=False, prologue=False, functional_mode=False):
     if new:
         state.initialize()

--- a/asteroid/repl.py
+++ b/asteroid/repl.py
@@ -44,7 +44,7 @@ def print_repl_menu():
 #by the user, while state is the number of times the function was called before
 #a valid completion was returned. The function will be called again if a string is
 #returned, and will stop being called if a non string object is returned.
-def completion_func(text, state):
+def completion_function(text, state):
     #Here we "hijack" the iteration with readline's calling of the function by
     #iterating on our own only on the first call, returning None on
     #all other calls of the function
@@ -151,7 +151,7 @@ def completion_func(text, state):
 def run_repl(redundancy, functional_mode):
     #Setup the autocompleter
     readline.parse_and_bind("Tab: complete")
-    readline.set_completer(completion_func)
+    readline.set_completer(completion_function)
     
     # The two different prompt types either > for a new statement
     # or . for continuing one

--- a/asteroid/repl.py
+++ b/asteroid/repl.py
@@ -10,8 +10,8 @@ from asteroid.state import state
 from asteroid.globals import ExpectationError
 from asteroid.walk import function_return_value
 from asteroid.support import term2string
-from lex import get_indentifiers
-from lex import get_member_identifiers
+from asteroid.lex import get_indentifiers
+from asteroid.lex import get_member_identifiers
 from sys import stdin,exit
 
 import readline

--- a/asteroid/repl.py
+++ b/asteroid/repl.py
@@ -10,8 +10,8 @@ from asteroid.state import state
 from asteroid.globals import ExpectationError
 from asteroid.walk import function_return_value
 from asteroid.support import term2string
-from lex import get_indentifiers
-from lex import get_member_identifiers
+from asteroid.lex import get_indentifiers
+from asteroid.lex import get_member_identifiers
 from sys import stdin,exit
 
 import readline
@@ -63,6 +63,7 @@ def completion_function(text, state):
                     prologue=False,
                     functional_mode=False,
                     exceptions=True)
+            identifiers = get_indentifiers()
         
         #Here we start checking if we are doing a completion for accessing a member
         user_in = readline.get_line_buffer()

--- a/asteroid/repl.py
+++ b/asteroid/repl.py
@@ -21,7 +21,7 @@ last_completion = ""
 last_index = 0
 
 #Change this flag to False to disable autocompletion
-repl_use_autocompletion = True
+state.repl_use_autocompletion = True
 
 def repl(new=True, redundancy=False, prologue=False, functional_mode=False):
     if new:
@@ -152,7 +152,7 @@ def completion_function(text, state):
 
 def run_repl(redundancy, functional_mode):
     #Setup the autocompleter
-    if repl_use_autocompletion:
+    if state.repl_use_autocompletion:
         readline.parse_and_bind("Tab: complete")
         readline.set_completer(completion_function)
     

--- a/asteroid/repl.py
+++ b/asteroid/repl.py
@@ -4,16 +4,14 @@
 # (c) University of Rhode Island
 ###########################################################################################
 
-from asteroid.interp import interp, load_prologue
+from interp import interp, load_prologue
 from asteroid.version import VERSION
 from asteroid.state import state
 from asteroid.globals import ExpectationError
 from asteroid.walk import function_return_value
 from asteroid.support import term2string
-from asteroid.lex import get_indentifiers
-from asteroid.lex import get_member_identifiers
+from lex import get_indentifiers, get_member_identifiers, repl_use_autocompletion
 from sys import stdin,exit
-
 import readline
 import re
 
@@ -151,8 +149,9 @@ def completion_function(text, state):
 
 def run_repl(redundancy, functional_mode):
     #Setup the autocompleter
-    readline.parse_and_bind("Tab: complete")
-    readline.set_completer(completion_function)
+    if repl_use_autocompletion:
+        readline.parse_and_bind("Tab: complete")
+        readline.set_completer(completion_function)
     
     # The two different prompt types either > for a new statement
     # or . for continuing one

--- a/asteroid/repl.py
+++ b/asteroid/repl.py
@@ -23,7 +23,6 @@ last_completion = ""
 last_index = 0
 
 def repl(new=True, redundancy=False, prologue=False, functional_mode=False):
-
     if new:
         state.initialize()
         if prologue:
@@ -101,7 +100,6 @@ def completion_func(text, state):
                     parent_id = user_in[i] + parent_id
                 else:
                     break
-                
                 i -= 1
 
             #Only try to set identifiers to member_list if the
@@ -111,7 +109,6 @@ def completion_func(text, state):
                 #Make sure the parent is actually a parent
                 if member_list:
                     identifiers = list(member_list)
-        
         
         global last_completion
         global last_index

--- a/asteroid/state.py
+++ b/asteroid/state.py
@@ -25,6 +25,7 @@ class State:
         # this.
         self.error_trace = None
         self.debugger = None
+        self.repl_use_autocompletion = True
 
 state = State()
 

--- a/asteroid/test-suites/python-tests/repl_test.py
+++ b/asteroid/test-suites/python-tests/repl_test.py
@@ -10,7 +10,7 @@ os.chdir(file_path)
 sys.path.append(grandparent_dir)
 
 from asteroid.interp import interp
-import asteroid.lex as lex
+import lex as lex
 from asteroid.state import state
 
 def test_get_identifiers():
@@ -18,10 +18,10 @@ def test_get_identifiers():
     interp("load io.", "test")
     print(lex.get_indentifiers())
     interp("let aaa = 1.", "test")
-    interp("let aab = 2.", "test", initialize_state=False)
-    interp("let abc = 3.", "test", initialize_state=False)
-    interp("let bc = 4.", "test", initialize_state=False)
-    interp("let baa = 5.", "test", initialize_state=False)
+    interp("let aab = 2.", "test", initialize_state=False, prologue=False)
+    interp("let abc = 3.", "test", initialize_state=False, prologue=False)
+    interp("let bc = 4.", "test", initialize_state=False, prologue=False)
+    interp("let baa = 5.", "test", initialize_state=False, prologue=False)
     print(lex.get_indentifiers())
     
 def test_get_identifiers_by_prefix():
@@ -29,10 +29,10 @@ def test_get_identifiers_by_prefix():
     interp("load io.", "test")
     print(lex.get_indentifiers())
     interp("let aaa = 1.", "test")
-    interp("let aab = 2.", "test", initialize_state=False)
-    interp("let abc = 3.", "test", initialize_state=False)
-    interp("let bc = 4.", "test", initialize_state=False)
-    interp("let baa = 5.", "test", initialize_state=False)
+    interp("let aab = 2.", "test", initialize_state=False, prologue=False)
+    interp("let abc = 3.", "test", initialize_state=False, prologue=False)
+    interp("let bc = 4.", "test", initialize_state=False, prologue=False)
+    interp("let baa = 5.", "test", initialize_state=False, prologue=False)
     print(lex.get_indentifiers())
     print(lex.get_indentifiers_by_prefix("a"))
     print(lex.get_indentifiers_by_prefix("aa"))
@@ -40,20 +40,20 @@ def test_get_identifiers_by_prefix():
     
 def test_get_member_identifiers():
     interp("load io.")
-    interp('structure A with\n\tdata a.\n\tdata b.\nend.', initialize_state=False)
-    interp('let foo = A(1,2).', initialize_state=False)
+    interp('structure A with\n\tdata a.\n\tdata b.\nend.', initialize_state=False, prologue=False)
+    interp('let foo = A(1,2).', initialize_state=False, prologue=False)
     print(lex.get_member_identifiers("io"))
     print(lex.get_member_identifiers("A"))
     print(lex.get_member_identifiers("foo"))
 
 if __name__ == "__main__":
-    print("Testing get_identifiers:")
+    print("Testing get_identifiers:\n")
     test_get_identifiers()
     print("\n\n\n")
-    print("Testing get_identifiers_by_prefix")
+    print("Testing get_identifiers_by_prefix:\n")
     test_get_identifiers_by_prefix()
     print("\n\n\n")
-    print("Testing get_member_identifiers")
+    print("Testing get_member_identifiers:\n")
     test_get_member_identifiers()
     print("\n\nTesting complete.")
     

--- a/asteroid/test-suites/python-tests/repl_test.py
+++ b/asteroid/test-suites/python-tests/repl_test.py
@@ -38,6 +38,13 @@ def test_get_identifiers_by_prefix():
     print(lex.get_indentifiers_by_prefix("aa"))
     print(lex.get_indentifiers_by_prefix("__"))
     
+def test_get_member_identifiers():
+    interp("load io.")
+    interp('structure A with\n\tdata a.\n\tdata b.\nend.', initialize_state=False)
+    interp('let foo = A(1,2).', initialize_state=False)
+    print(lex.get_member_identifiers("io"))
+    print(lex.get_member_identifiers("A"))
+    print(lex.get_member_identifiers("foo"))
 
 if __name__ == "__main__":
     print("Testing get_identifiers:")
@@ -45,3 +52,8 @@ if __name__ == "__main__":
     print("\n\n\n")
     print("Testing get_identifiers_by_prefix")
     test_get_identifiers_by_prefix()
+    print("\n\n\n")
+    print("Testing get_member_identifiers")
+    test_get_member_identifiers()
+    print("\n\nTesting complete.")
+    

--- a/asteroid/test-suites/python-tests/repl_test.py
+++ b/asteroid/test-suites/python-tests/repl_test.py
@@ -10,7 +10,7 @@ os.chdir(file_path)
 sys.path.append(grandparent_dir)
 
 from asteroid.interp import interp
-import lex as lex
+import asteroid.lex as lex
 from asteroid.state import state
 
 def test_get_identifiers():

--- a/asteroid/test-suites/python-tests/repl_test.py
+++ b/asteroid/test-suites/python-tests/repl_test.py
@@ -9,10 +9,9 @@ os.chdir(file_path)
 (grandparent_dir,_) = os.path.split(parent_dir)
 sys.path.append(grandparent_dir)
 
-
 from asteroid.interp import interp
-import lex
-from state import state
+import asteroid.lex as lex
+from asteroid.state import state
 
 def test_get_identifiers():
     print(lex.get_indentifiers())

--- a/asteroid/test-suites/python-tests/repl_test.py
+++ b/asteroid/test-suites/python-tests/repl_test.py
@@ -10,7 +10,7 @@ os.chdir(file_path)
 sys.path.append(grandparent_dir)
 
 from asteroid.interp import interp
-import asteroid.lex as lex
+import lex as lex
 from asteroid.state import state
 
 def test_get_identifiers():
@@ -45,8 +45,10 @@ def test_get_member_identifiers():
     print(lex.get_member_identifiers("io"))
     print(lex.get_member_identifiers("A"))
     print(lex.get_member_identifiers("foo"))
+    return None
 
 if __name__ == "__main__":
+    test_get_member_identifiers()
     print("Testing get_identifiers:\n")
     test_get_identifiers()
     print("\n\n\n")
@@ -56,4 +58,5 @@ if __name__ == "__main__":
     print("Testing get_member_identifiers:\n")
     test_get_member_identifiers()
     print("\n\nTesting complete.")
+    
     


### PR DESCRIPTION
This pull request covers the milestones for 3/18/2024, 4/1/2024 and 4/15/2024.
 
The changes in `repl.py` are largely found in the `completion_function` (formerly `completion_func`). A tab press will now behave as follows:
1. Any tab press will cycle through completions instead of only modifying the input_buffer when there is only one possible completion.
2. If the completion is after an @ and that @ is after a valid object or struct name, the pool of completions will correspond to the members of the struct
3. If the completion is after an @ and that @ is after a valid module, the pool of completions will correspond to the variables inside of that module.

The change in lex.py is the addition of the `get_member_identifiers()`, which will give you the identifiers of either the members of a struct/object, or the variables of a module if the identifier is valid, or `None` otherwise.